### PR TITLE
docs: add next flag

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -27,8 +27,8 @@ const config: UserConfig<DefaultThemeOptions> = {
       },
     ],
     ['link', { rel: 'manifest', href: '/manifest.webmanifest' }],
-    ['meta', { name: 'application-name', content: 'VuePress' }],
-    ['meta', { name: 'apple-mobile-web-app-title', content: 'VuePress' }],
+    ['meta', { name: 'application-name', content: 'VuePress Next' }],
+    ['meta', { name: 'apple-mobile-web-app-title', content: 'VuePress Next' }],
     [
       'meta',
       { name: 'apple-mobile-web-app-status-bar-style', content: 'black' },
@@ -53,12 +53,12 @@ const config: UserConfig<DefaultThemeOptions> = {
   locales: {
     '/': {
       lang: 'en-US',
-      title: 'VuePress',
+      title: 'VuePress Next',
       description: 'Vue-powered Static Site Generator',
     },
     '/zh/': {
       lang: 'zh-CN',
-      title: 'VuePress',
+      title: 'VuePress Next',
       description: 'Vue 驱动的静态网站生成器',
     },
   },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "docs:build": "vuepress build docs --clean-cache",
     "docs:clean": "rimraf docs/.vuepress/.temp docs/.vuepress/.cache docs/.vuepress/dist",
     "docs:dev": "vuepress dev docs --clean-cache",
+    "docs:release": "yarn copy && yarn build && yarn docs:build",
     "docs:serve": "anywhere -h localhost -d docs/.vuepress/dist",
     "lint": "cross-env NODE_OPTIONS=\"--max-old-space-size=4096\" eslint --ext .js,.ts,.vue .",
     "release": "yarn lint && yarn clean && yarn copy && yarn build && yarn test && lerna publish prerelease --dist-tag next",


### PR DESCRIPTION
- Add config to make it easier to deploy
- Signify that it's the next repo so users aren't confused