### PR TITLE
docs: add plugin link in migration guide

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -103,7 +103,7 @@ See [Bundlers > Webpack](../reference/bundler/webpack.md)
 Removed.
 
 Use [head](../reference/frontmatter.md#head) instead. For example:
-  
+
 ```yaml
 head:
   - - meta
@@ -156,7 +156,7 @@ If you are using default theme, the palette system is still available but migrat
 
 #### .vuepress/enhanceApp.js
 
-Renamed to `.vuepress/clientAppEnhance.{js,ts}`. 
+Renamed to `.vuepress/clientAppEnhance.{js,ts}`.
 
 The arguments of the function are changed, too.
 
@@ -164,7 +164,7 @@ The arguments of the function are changed, too.
 
 Files in this directory will not be registered as Vue components automatically.
 
-You need to use `@vuepress/plugin-register-components`, or register your components manually in `.vuepress/clientAppEnhance.{js,ts}`.
+You need to use [@vuepress/plugin-register-components](../reference/plugin/register-components.md), or register your components manually in `.vuepress/clientAppEnhance.{js,ts}`.
 
 #### .vuepress/theme/
 
@@ -268,7 +268,7 @@ Some major breaking changes:
 
 - There is no **conventional theme directory structure** anymore.
   - The file `theme/enhanceApp.js` or `theme/clientAppEnhance.{js,ts}` will not be used as client app enhance file implicitly. You need to specify it explicitly in `clientAppEnhanceFiles` hook.
-  - Files in `theme/global-components/` directory will not be registered as Vue components automatically. You need to use `@vuepress/plugin-register-components`, or register components manually in `clientAppEnhance.{js,ts}`.
+  - Files in `theme/global-components/` directory will not be registered as Vue components automatically. You need to use [@vuepress/plugin-register-components](../reference/plugin/register-components.md), or register components manually in `clientAppEnhance.{js,ts}`.
   - Files in `theme/layouts/` directory will not be registered as layout components automatically. You need to specify it explicitly in `layouts` option.
   - Files in `theme/templates/` directory will not be used as dev / ssr template automatically.
   - Always provide a theme entry file, and do not use `"main": "layouts/Layout.vue"` as the theme entry.

--- a/docs/zh/guide/migration.md
+++ b/docs/zh/guide/migration.md
@@ -164,7 +164,7 @@ VuePress v1 的 Stylus 调色板系统 （即 `styles/palette.styl` 和 `styles/
 
 在该目录下的文件不会被自动注册为 Vue 组件。
 
-你需要使用 `@vuepress/plugin-register-components` ，或者在 `.vuepress/clientAppEnhance.{js,ts}` 中手动注册你的组件。
+你需要使用 [@vuepress/plugin-register-components](../reference/plugin/register-components.md) ，或者在 `.vuepress/clientAppEnhance.{js,ts}` 中手动注册你的组件。
 
 #### .vuepress/theme/
 
@@ -268,7 +268,7 @@ v1 的主题和插件和 v2 并不兼容。
 
 - 所谓的 **主题目录结构约定** 不再存在。
   - `theme/enhanceApp.js` 或 `theme/clientAppEnhance.{js,ts}` 文件不会被隐式作为 Client App Enhance 文件。你需要在 `clientAppEnhanceFiles` Hook 中显式指定它。
-  - `theme/global-components/` 目录下的文件不会被自动注册为 Vue 组件。你需要使用 `@vuepress/plugin-register-components` ，或者在 `clientAppEnhance.{js,ts}` 中手动注册组件。
+  - `theme/global-components/` 目录下的文件不会被自动注册为 Vue 组件。你需要使用 [@vuepress/plugin-register-components](../reference/plugin/register-components.md) ，或者在 `clientAppEnhance.{js,ts}` 中手动注册组件。
   - `theme/layouts/` 目录下的文件不会被自动注册为布局组件。你需要通过 `layouts` 配置项来显式指定。
   - `theme/templates/` 目录下的文件不会被自动作为 dev / ssr 的模板。
   - 你始终需要提供主题入口文件，并且不要使用 `"main": "layouts/Layout.vue"` 作为主题入口。

--- a/docs/zh/guide/migration.md
+++ b/docs/zh/guide/migration.md
@@ -103,7 +103,7 @@ VuePress v2 的核心思想和流程是和 v1 一致的，但 v2 API 经过了�
 移除。
 
 改为使用 [head](../reference/frontmatter.md#head) 。例如：
-  
+
 ```yaml
 head:
   - - meta


### PR DESCRIPTION
Following https://github.com/vuepress/vuepress-next/issues/112 