### PR TITLE
docs: add example for registering non-SSR-friendly global plugins

### DIFF
--- a/docs/reference/client-api.md
+++ b/docs/reference/client-api.md
@@ -84,6 +84,27 @@ export default defineClientAppEnhance(({ app, router, siteData }) => {
 })
 ```
 
+::: tip
+
+Environment variables `__SSR__` and `__DEV__` are availalbe in the callback function.
+
+:::
+
+You can use async import to load any global features that are not SSR-friendly:
+
+```ts
+export default defineClientAppEnhance(({ app, router, siteData }) => {
+  // ...
+  if (!__SSR__) {
+    // register client-side plugins with async imports
+    const module = await import('non-ssr-friendly-plugin')
+    const plugin = module.default
+    app.use(plugin)
+    // ...
+  }
+})
+```
+
 ### defineClientAppSetup
 
 - Details:

--- a/docs/reference/client-api.md
+++ b/docs/reference/client-api.md
@@ -93,7 +93,7 @@ Environment variables `__SSR__` and `__DEV__` are availalbe in the callback func
 You can use async import to load any global features that are not SSR-friendly:
 
 ```ts
-export default defineClientAppEnhance(({ app, router, siteData }) => {
+export default defineClientAppEnhance( async ({ app, router, siteData }) => {
   // ...
   if (!__SSR__) {
     // register client-side plugins with async imports

--- a/docs/zh/reference/client-api.md
+++ b/docs/zh/reference/client-api.md
@@ -84,6 +84,27 @@ export default defineClientAppEnhance(({ app, router, siteData }) => {
 })
 ```
 
+::: tip
+
+回调函数中提供了环境变量`__SSR__`和`__DEV__`
+
+:::
+
+您可以使用异步导入来加载任何不支持SSR的全局功能:
+
+```ts
+export default defineClientAppEnhance( async ({ app, router, siteData }) => {
+  // ...
+  if (!__SSR__) {
+    // 用异步导入注册客户端插件
+    const module = await import('non-ssr-friendly-plugin')
+    const plugin = module.default
+    app.use(plugin)
+    // ...
+  }
+})
+```
+
 ### defineClientAppSetup
 
 - 详情：


### PR DESCRIPTION
I got build error of `window is not defined` whenever I register a plugin, couldn't really find any docs on it. 

Found an example in the google analytics plugin that uses `__SSR__` and `__DEV__` got it working together with `await import`