### PR TITLE
fix(theme-default): align the font of line numbers with code blocks (close #124)

### DIFF
--- a/packages/@vuepress/theme-default/src/client/styles/code.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/code.scss
@@ -154,7 +154,7 @@ pre[class*='language-'] {
   }
 
   .line-number {
-    font-family: source-code-pro, Menlo, Monaco, Consolas, monospace;
+    font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
   }
 }
 

--- a/packages/@vuepress/theme-default/src/client/styles/code.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/code.scss
@@ -154,8 +154,7 @@ pre[class*='language-'] {
   }
 
   .line-number {
-    font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-      monospace;
+    font-family: source-code-pro, Menlo, Monaco, Consolas, monospace;
   }
 }
 


### PR DESCRIPTION
Closes #124 by removing `'Courier New'` as font which caused the issue.

Must I adjust https://github.com/vuepress/vuepress-next/blob/e971d6aa216102befaa387e062d49b3632fe579c/packages/%40vuepress/theme-default/src/client/styles/_normalize.scss#L114 as well?

Not quite sure if the fix is in `core`, maybe adjust the commit message when merging.