### PR TITLE
docs: make guide for .gitignore work on Windows

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -72,7 +72,9 @@ npm install -D vuepress@next
 - **Step 5**: Add the default temp and cache directory to `.gitignore` file
 
 ```bash
-echo 'node_modules\n.temp\n.cache' >> .gitignore
+echo 'node_modules' >> .gitignore
+echo '.temp' >> .gitignore
+echo '.cache' >> .gitignore
 ```
 
 - **Step 6**: Create your first document

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -73,7 +73,9 @@ npm install -D vuepress@next
 - **步骤5**: 将默认的临时目录和缓存目录添加到 `.gitignore` 文件中
 
 ```bash
-echo 'node_modules\n.temp\n.cache' >> .gitignore
+echo 'node_modules' >> .gitignore
+echo '.temp' >> .gitignore
+echo '.cache' >> .gitignore
 ```
 
 - **步骤6**: 创建你的第一篇文档


### PR DESCRIPTION
When executing `echo 'node_modules\n.temp\n.cache' >> .gitignore` in PowerShell on Windows, pwsh appends a single line `node_modules\n.temp\n.cache` to .gitignore file. Change it to adding each line respectively so that it can work in PowerShell.