### PR TITLE
fix(markdown): decode assets link to ensure bundler can find the file

### DIFF
--- a/packages/@vuepress/markdown/__tests__/plugins/assetsPlugin.spec.ts
+++ b/packages/@vuepress/markdown/__tests__/plugins/assetsPlugin.spec.ts
@@ -64,8 +64,8 @@ describe('@vuepress/markdown > plugins > assetsPlugin', () => {
         '<img src="" alt="empty">',
         // invalid paths
         '<img src=".../invalid.png" alt="invalid">',
-        '<img src=".../%E6%B1%89%E5%AD%97.png" alt="汉字">',
-        '<img src=".../100%25.png" alt="100%">',
+        '<img src=".../汉字.png" alt="汉字">',
+        '<img src=".../100%.png" alt="100%">',
       ]
         .map((item) => `<p>${item}</p>`)
         .join('\n') + '\n'
@@ -107,8 +107,8 @@ describe('@vuepress/markdown > plugins > assetsPlugin', () => {
         '<img src="" alt="empty">',
         // invalid paths
         '<img src=".../invalid.png" alt="invalid">',
-        '<img src=".../%E6%B1%89%E5%AD%97.png" alt="汉字">',
-        '<img src=".../100%25.png" alt="100%">',
+        '<img src=".../汉字.png" alt="汉字">',
+        '<img src=".../100%.png" alt="100%">',
       ]
         .map((item) => `<p>${item}</p>`)
         .join('\n') + '\n'
@@ -130,8 +130,8 @@ describe('@vuepress/markdown > plugins > assetsPlugin', () => {
         '<img src="../sub/foo/bar.png" alt="foo-bar2">',
         '<img src="../baz.png" alt="baz">',
         '<img src="../../out.png" alt="out">',
-        '<img src="./%E6%B1%89%E5%AD%97.png" alt="汉字">',
-        '<img src="./100%25.png" alt="100%">',
+        '<img src="./汉字.png" alt="汉字">',
+        '<img src="./100%.png" alt="100%">',
         // aliases
         '<img src="@alias/foo.png" alt="alias">',
         '<img src="@alias/汉字.png" alt="汉字">',
@@ -146,8 +146,8 @@ describe('@vuepress/markdown > plugins > assetsPlugin', () => {
         '<img src="" alt="empty">',
         // invalid paths
         '<img src=".../invalid.png" alt="invalid">',
-        '<img src=".../%E6%B1%89%E5%AD%97.png" alt="汉字">',
-        '<img src=".../100%25.png" alt="100%">',
+        '<img src=".../汉字.png" alt="汉字">',
+        '<img src=".../100%.png" alt="100%">',
       ]
         .map((item) => `<p>${item}</p>`)
         .join('\n') + '\n'

--- a/packages/@vuepress/markdown/__tests__/plugins/assetsPlugin.spec.ts
+++ b/packages/@vuepress/markdown/__tests__/plugins/assetsPlugin.spec.ts
@@ -15,6 +15,8 @@ const source = [
   '![empty]()',
   '![alias](@alias/foo.png)',
   '![~alias](~@alias/foo.png)',
+  '![中国](./中国.png)',
+  '![finish](./100%.png)',
 ].join('\n\n')
 
 describe('@vuepress/markdown > plugins > assetsPlugin', () => {
@@ -40,6 +42,8 @@ describe('@vuepress/markdown > plugins > assetsPlugin', () => {
         '<img src="" alt="empty">',
         '<img src="@alias/foo.png" alt="alias">',
         '<img src="~@alias/foo.png" alt="~alias">',
+        '<img src="@source/sub/中国.png" alt="中国">',
+        '<img src="@source/sub/100%.png" alt="finish">',
       ]
         .map((item) => `<p>${item}</p>`)
         .join('\n') + '\n'
@@ -70,6 +74,8 @@ describe('@vuepress/markdown > plugins > assetsPlugin', () => {
         '<img src="" alt="empty">',
         '<img src="@alias/foo.png" alt="alias">',
         '<img src="~@alias/foo.png" alt="~alias">',
+        '<img src="@foo/sub/中国.png" alt="中国">',
+        '<img src="@foo/sub/100%.png" alt="finish">',
       ]
         .map((item) => `<p>${item}</p>`)
         .join('\n') + '\n'
@@ -96,6 +102,8 @@ describe('@vuepress/markdown > plugins > assetsPlugin', () => {
         '<img src="" alt="empty">',
         '<img src="@alias/foo.png" alt="alias">',
         '<img src="~@alias/foo.png" alt="~alias">',
+        '<img src="./%E4%B8%AD%E5%9B%BD.png" alt="中国">',
+        '<img src="./100%25.png" alt="finish">',
       ]
         .map((item) => `<p>${item}</p>`)
         .join('\n') + '\n'

--- a/packages/@vuepress/markdown/__tests__/plugins/assetsPlugin.spec.ts
+++ b/packages/@vuepress/markdown/__tests__/plugins/assetsPlugin.spec.ts
@@ -3,20 +3,31 @@ import { assetsPlugin } from '@vuepress/markdown'
 import type { MarkdownEnv } from '@vuepress/markdown'
 
 const source = [
+  // relative paths
   '![foo](./foo.png)',
   '![foo2](../sub/foo.png)',
   '![foo-bar](./foo/bar.png)',
   '![foo-bar2](../sub/foo/bar.png)',
   '![baz](../baz.png)',
   '![out](../../out.png)',
-  '![invalid](.../invalid.png)',
+  '![汉字](./汉字.png)',
+  '![100%](./100%.png)',
+  // aliases
+  '![alias](@alias/foo.png)',
+  '![汉字](@alias/汉字.png)',
+  '![100%](@alias/100%.png)',
+  // webpack legacy aliases
+  '![~alias](~@alias/foo.png)',
+  '![~汉字](~@alias/汉字.png)',
+  '![~100%](~@alias/100%.png)',
+  // keep as is
   '![absolute](/absolute.png)',
   '![url](http://foobar.com/icon.png)',
   '![empty]()',
-  '![alias](@alias/foo.png)',
-  '![~alias](~@alias/foo.png)',
-  '![中国](./中国.png)',
-  '![finish](./100%.png)',
+  // invalid paths
+  '![invalid](.../invalid.png)',
+  '![汉字](.../汉字.png)',
+  '![100%](.../100%.png)',
 ].join('\n\n')
 
 describe('@vuepress/markdown > plugins > assetsPlugin', () => {
@@ -30,20 +41,31 @@ describe('@vuepress/markdown > plugins > assetsPlugin', () => {
 
     expect(rendered).toEqual(
       [
+        // relative paths
         '<img src="@source/sub/foo.png" alt="foo">',
         '<img src="@source/sub/foo.png" alt="foo2">',
         '<img src="@source/sub/foo/bar.png" alt="foo-bar">',
         '<img src="@source/sub/foo/bar.png" alt="foo-bar2">',
         '<img src="@source/baz.png" alt="baz">',
         '<img src="@source/../out.png" alt="out">',
-        '<img src=".../invalid.png" alt="invalid">',
+        '<img src="@source/sub/汉字.png" alt="汉字">',
+        '<img src="@source/sub/100%.png" alt="100%">',
+        // aliases
+        '<img src="@alias/foo.png" alt="alias">',
+        '<img src="@alias/汉字.png" alt="汉字">',
+        '<img src="@alias/100%.png" alt="100%">',
+        // webpack legacy aliases
+        '<img src="~@alias/foo.png" alt="~alias">',
+        '<img src="~@alias/汉字.png" alt="~汉字">',
+        '<img src="~@alias/100%.png" alt="~100%">',
+        // keep as is
         '<img src="/absolute.png" alt="absolute">',
         '<img src="http://foobar.com/icon.png" alt="url">',
         '<img src="" alt="empty">',
-        '<img src="@alias/foo.png" alt="alias">',
-        '<img src="~@alias/foo.png" alt="~alias">',
-        '<img src="@source/sub/中国.png" alt="中国">',
-        '<img src="@source/sub/100%.png" alt="finish">',
+        // invalid paths
+        '<img src=".../invalid.png" alt="invalid">',
+        '<img src=".../%E6%B1%89%E5%AD%97.png" alt="汉字">',
+        '<img src=".../100%25.png" alt="100%">',
       ]
         .map((item) => `<p>${item}</p>`)
         .join('\n') + '\n'
@@ -62,20 +84,31 @@ describe('@vuepress/markdown > plugins > assetsPlugin', () => {
 
     expect(rendered).toEqual(
       [
+        // relative paths
         '<img src="@foo/sub/foo.png" alt="foo">',
         '<img src="@foo/sub/foo.png" alt="foo2">',
         '<img src="@foo/sub/foo/bar.png" alt="foo-bar">',
         '<img src="@foo/sub/foo/bar.png" alt="foo-bar2">',
         '<img src="@foo/baz.png" alt="baz">',
         '<img src="@foo/../out.png" alt="out">',
-        '<img src=".../invalid.png" alt="invalid">',
+        '<img src="@foo/sub/汉字.png" alt="汉字">',
+        '<img src="@foo/sub/100%.png" alt="100%">',
+        // aliases
+        '<img src="@alias/foo.png" alt="alias">',
+        '<img src="@alias/汉字.png" alt="汉字">',
+        '<img src="@alias/100%.png" alt="100%">',
+        // webpack legacy aliases
+        '<img src="~@alias/foo.png" alt="~alias">',
+        '<img src="~@alias/汉字.png" alt="~汉字">',
+        '<img src="~@alias/100%.png" alt="~100%">',
+        // keep as is
         '<img src="/absolute.png" alt="absolute">',
         '<img src="http://foobar.com/icon.png" alt="url">',
         '<img src="" alt="empty">',
-        '<img src="@alias/foo.png" alt="alias">',
-        '<img src="~@alias/foo.png" alt="~alias">',
-        '<img src="@foo/sub/中国.png" alt="中国">',
-        '<img src="@foo/sub/100%.png" alt="finish">',
+        // invalid paths
+        '<img src=".../invalid.png" alt="invalid">',
+        '<img src=".../%E6%B1%89%E5%AD%97.png" alt="汉字">',
+        '<img src=".../100%25.png" alt="100%">',
       ]
         .map((item) => `<p>${item}</p>`)
         .join('\n') + '\n'
@@ -90,20 +123,31 @@ describe('@vuepress/markdown > plugins > assetsPlugin', () => {
 
     expect(rendered).toEqual(
       [
+        // relative paths
         '<img src="./foo.png" alt="foo">',
         '<img src="../sub/foo.png" alt="foo2">',
         '<img src="./foo/bar.png" alt="foo-bar">',
         '<img src="../sub/foo/bar.png" alt="foo-bar2">',
         '<img src="../baz.png" alt="baz">',
         '<img src="../../out.png" alt="out">',
-        '<img src=".../invalid.png" alt="invalid">',
+        '<img src="./%E6%B1%89%E5%AD%97.png" alt="汉字">',
+        '<img src="./100%25.png" alt="100%">',
+        // aliases
+        '<img src="@alias/foo.png" alt="alias">',
+        '<img src="@alias/汉字.png" alt="汉字">',
+        '<img src="@alias/100%.png" alt="100%">',
+        // webpack legacy aliases
+        '<img src="~@alias/foo.png" alt="~alias">',
+        '<img src="~@alias/汉字.png" alt="~汉字">',
+        '<img src="~@alias/100%.png" alt="~100%">',
+        // keep as is
         '<img src="/absolute.png" alt="absolute">',
         '<img src="http://foobar.com/icon.png" alt="url">',
         '<img src="" alt="empty">',
-        '<img src="@alias/foo.png" alt="alias">',
-        '<img src="~@alias/foo.png" alt="~alias">',
-        '<img src="./%E4%B8%AD%E5%9B%BD.png" alt="中国">',
-        '<img src="./100%25.png" alt="finish">',
+        // invalid paths
+        '<img src=".../invalid.png" alt="invalid">',
+        '<img src=".../%E6%B1%89%E5%AD%97.png" alt="汉字">',
+        '<img src=".../100%25.png" alt="100%">',
       ]
         .map((item) => `<p>${item}</p>`)
         .join('\n') + '\n'

--- a/packages/@vuepress/markdown/package.json
+++ b/packages/@vuepress/markdown/package.json
@@ -31,7 +31,8 @@
     "@vuepress/utils": "2.0.0-beta.11",
     "markdown-it": "^12.0.6",
     "markdown-it-anchor": "^7.1.0",
-    "markdown-it-emoji": "^2.0.0"
+    "markdown-it-emoji": "^2.0.0",
+    "mdurl": "^1.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vuepress/markdown/src/plugins/assetsPlugin.ts
+++ b/packages/@vuepress/markdown/src/plugins/assetsPlugin.ts
@@ -22,25 +22,27 @@ export const assetsPlugin: PluginWithOptions<AssetsPluginOptions> = (
   md.renderer.rules.image = (tokens, idx, options, env: MarkdownEnv, self) => {
     const token = tokens[idx]
 
-    // get the image link and decode link to the origin one
-    // so that bundler can find the file correctly
+    // get the image link
     const link = token.attrGet('src')
 
-    if (link) {
-      if (/^\.{1,2}\//.test(link) && env.filePathRelative) {
-        // if the link is relative path, and the `env.filePathRelative` exists
-        // add `@source` alias to the link
-        const resolvedLink = `${relativePathPrefix}/${path.join(
-          path.dirname(env.filePathRelative),
-          decode(link)
-        )}`
-
-        // replace the original link with absolute path
-        token.attrSet('src', resolvedLink)
-      } else {
-        token.attrSet('src', decode(link))
-      }
+    if (!link) {
+      return rawRule(tokens, idx, options, env, self)
     }
+
+    // decode link to ensure bundler can find the file correctly
+    let resolvedLink = decode(link)
+
+    // if the link is relative path, and the `env.filePathRelative` exists
+    // add `@source` alias to the link
+    if (/^\.{1,2}\//.test(link) && env.filePathRelative) {
+      resolvedLink = `${relativePathPrefix}/${path.join(
+        path.dirname(env.filePathRelative),
+        resolvedLink
+      )}`
+    }
+
+    // replace the original link with resolved link
+    token.attrSet('src', resolvedLink)
 
     return rawRule(tokens, idx, options, env, self)
   }

--- a/packages/@vuepress/markdown/src/plugins/assetsPlugin.ts
+++ b/packages/@vuepress/markdown/src/plugins/assetsPlugin.ts
@@ -1,4 +1,5 @@
 import type { PluginWithOptions } from 'markdown-it'
+import { decode } from 'mdurl'
 import { path } from '@vuepress/utils'
 import type { MarkdownEnv } from '../types'
 
@@ -29,7 +30,8 @@ export const assetsPlugin: PluginWithOptions<AssetsPluginOptions> = (
       // add `@source` alias to the link
       const resolvedLink = `${relativePathPrefix}/${path.join(
         path.dirname(env.filePathRelative),
-        link
+        // decode link to the origin one so that bundler can find the file correctly
+        decode(link)
       )}`
 
       // replace the original link with absolute path

--- a/packages/@vuepress/markdown/src/plugins/assetsPlugin.ts
+++ b/packages/@vuepress/markdown/src/plugins/assetsPlugin.ts
@@ -22,20 +22,24 @@ export const assetsPlugin: PluginWithOptions<AssetsPluginOptions> = (
   md.renderer.rules.image = (tokens, idx, options, env: MarkdownEnv, self) => {
     const token = tokens[idx]
 
-    // get the image link
+    // get the image link and decode link to the origin one
+    // so that bundler can find the file correctly
     const link = token.attrGet('src')
 
-    // if the link is relative path, and the `env.filePathRelative` exists
-    if (link && /^\.{1,2}\//.test(link) && env.filePathRelative) {
-      // add `@source` alias to the link
-      const resolvedLink = `${relativePathPrefix}/${path.join(
-        path.dirname(env.filePathRelative),
-        // decode link to the origin one so that bundler can find the file correctly
-        decode(link)
-      )}`
+    if (link) {
+      if (/^\.{1,2}\//.test(link) && env.filePathRelative) {
+        // if the link is relative path, and the `env.filePathRelative` exists
+        // add `@source` alias to the link
+        const resolvedLink = `${relativePathPrefix}/${path.join(
+          path.dirname(env.filePathRelative),
+          decode(link)
+        )}`
 
-      // replace the original link with absolute path
-      token.attrSet('src', resolvedLink)
+        // replace the original link with absolute path
+        token.attrSet('src', resolvedLink)
+      } else {
+        token.attrSet('src', decode(link))
+      }
     }
 
     return rawRule(tokens, idx, options, env, self)


### PR DESCRIPTION
This is an issue in all VuePress versions.

```md
![中国](./中国.png)
```

should be allowed. But `markdown-it` 's default behavior will encode it to `./%E4%B8%AD%E5%9B%BD.png`, so that  bundler won't be able to find the image file.

I made a fix in V1 by my `vuepress-plugin-md-enhance`, but I think V2 can support it.
