### PR TITLE
fix(theme-default): handle rotate events on iPad

### DIFF
--- a/packages/@vuepress/theme-default/src/client/components/Navbar.vue
+++ b/packages/@vuepress/theme-default/src/client/components/Navbar.vue
@@ -89,6 +89,7 @@ export default defineComponent({
       }
       handleLinksWrapWidth()
       window.addEventListener('resize', handleLinksWrapWidth, false)
+      window.addEventListener('orientationchange', handleLinksWrapWidth, false)
     })
 
     return {


### PR DESCRIPTION
On devices like iPad, the viewport will change during rotate, but the `resize` event won't be triggered.

Addtional `orientationchange` event should be listened to ensure navbar render correctly