### PR TITLE
build: add missing deps

### DIFF
--- a/packages/@vuepress/client/package.json
+++ b/packages/@vuepress/client/package.json
@@ -30,9 +30,11 @@
   },
   "dependencies": {
     "@vuepress/shared": "2.0.0-beta.7",
-    "vite": "^2.3.3",
     "vue": "^3.0.11",
     "vue-router": "^4.0.6"
+  },
+  "devDependencies": {
+    "vite": "^2.3.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vuepress/client/package.json
+++ b/packages/@vuepress/client/package.json
@@ -34,6 +34,7 @@
     "vue-router": "^4.0.6"
   },
   "devDependencies": {
+    "@types/webpack-env": "^1.16.0",
     "vite": "^2.3.3"
   },
   "publishConfig": {

--- a/packages/@vuepress/client/package.json
+++ b/packages/@vuepress/client/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@vuepress/shared": "2.0.0-beta.7",
+    "vite": "^2.3.3",
     "vue": "^3.0.11",
     "vue-router": "^4.0.6"
   },

--- a/packages/@vuepress/plugin-docsearch/package.json
+++ b/packages/@vuepress/plugin-docsearch/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@docsearch/css": "3.0.0-alpha.34",
     "@docsearch/js": "3.0.0-alpha.34",
-    "@docsearch/react": "3.0.0-alpha.34",
     "@types/react": "^17.0.0",
     "@vuepress/client": "2.0.0-beta.12",
     "@vuepress/core": "2.0.0-beta.14",
@@ -41,6 +40,9 @@
     "preact": "^10.0.0",
     "vue": "^3.0.11",
     "vue-router": "^4.0.6"
+  },
+  "devDependencies": {
+    "@docsearch/react": "3.0.0-alpha.34"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vuepress/plugin-docsearch/package.json
+++ b/packages/@vuepress/plugin-docsearch/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@docsearch/css": "3.0.0-alpha.34",
     "@docsearch/js": "3.0.0-alpha.34",
+    "@docsearch/react": "3.0.0-alpha.34",
     "@types/react": "^17.0.0",
     "@vuepress/client": "2.0.0-beta.12",
     "@vuepress/core": "2.0.0-beta.14",

--- a/packages/@vuepress/plugin-docsearch/package.json
+++ b/packages/@vuepress/plugin-docsearch/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@docsearch/css": "3.0.0-alpha.34",
     "@docsearch/js": "3.0.0-alpha.34",
+    "@docsearch/react": "3.0.0-alpha.34",
     "@types/react": "^17.0.0",
     "@vuepress/client": "2.0.0-beta.12",
     "@vuepress/core": "2.0.0-beta.14",
@@ -40,9 +41,6 @@
     "preact": "^10.0.0",
     "vue": "^3.0.11",
     "vue-router": "^4.0.6"
-  },
-  "devDependencies": {
-    "@docsearch/react": "3.0.0-alpha.34"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vuepress/plugin-pwa-popup/package.json
+++ b/packages/@vuepress/plugin-pwa-popup/package.json
@@ -34,7 +34,8 @@
     "@vuepress/core": "2.0.0-beta.14",
     "@vuepress/plugin-pwa": "2.0.0-beta.14",
     "@vuepress/shared": "2.0.0-beta.7",
-    "@vuepress/utils": "2.0.0-beta.11"
+    "@vuepress/utils": "2.0.0-beta.11",
+    "vue": "^3.0.11"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vuepress/plugin-search/package.json
+++ b/packages/@vuepress/plugin-search/package.json
@@ -38,6 +38,7 @@
     "vue-router": "^4.0.6"
   },
   "devDependencies": {
+    "@types/webpack-env": "^1.16.0",
     "vite": "^2.3.3"
   },
   "publishConfig": {

--- a/packages/@vuepress/plugin-search/package.json
+++ b/packages/@vuepress/plugin-search/package.json
@@ -34,9 +34,11 @@
     "@vuepress/shared": "2.0.0-beta.7",
     "@vuepress/utils": "2.0.0-beta.11",
     "chokidar": "^3.5.1",
-    "vite": "^2.3.3",
     "vue": "^3.0.11",
     "vue-router": "^4.0.6"
+  },
+  "devDependencies": {
+    "vite": "^2.3.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vuepress/plugin-search/package.json
+++ b/packages/@vuepress/plugin-search/package.json
@@ -34,6 +34,7 @@
     "@vuepress/shared": "2.0.0-beta.7",
     "@vuepress/utils": "2.0.0-beta.11",
     "chokidar": "^3.5.1",
+    "vite": "^2.3.3",
     "vue": "^3.0.11",
     "vue-router": "^4.0.6"
   },

--- a/packages/@vuepress/plugin-theme-data/package.json
+++ b/packages/@vuepress/plugin-theme-data/package.json
@@ -32,7 +32,9 @@
     "@vuepress/client": "2.0.0-beta.12",
     "@vuepress/core": "2.0.0-beta.14",
     "@vuepress/shared": "2.0.0-beta.7",
-    "@vuepress/utils": "2.0.0-beta.11"
+    "@vuepress/utils": "2.0.0-beta.11",
+    "vite": "^2.3.3",
+    "vue": "^3.0.11"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vuepress/plugin-theme-data/package.json
+++ b/packages/@vuepress/plugin-theme-data/package.json
@@ -36,6 +36,7 @@
     "vue": "^3.0.11"
   },
   "devDependencies": {
+    "@types/webpack-env": "^1.16.0",
     "vite": "^2.3.3"
   },
   "publishConfig": {

--- a/packages/@vuepress/plugin-theme-data/package.json
+++ b/packages/@vuepress/plugin-theme-data/package.json
@@ -33,8 +33,10 @@
     "@vuepress/core": "2.0.0-beta.14",
     "@vuepress/shared": "2.0.0-beta.7",
     "@vuepress/utils": "2.0.0-beta.11",
-    "vite": "^2.3.3",
     "vue": "^3.0.11"
+  },
+  "devDependencies": {
+    "vite": "^2.3.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vuepress/plugin-toc/package.json
+++ b/packages/@vuepress/plugin-toc/package.json
@@ -31,7 +31,8 @@
     "@vuepress/client": "2.0.0-beta.12",
     "@vuepress/core": "2.0.0-beta.14",
     "@vuepress/utils": "2.0.0-beta.11",
-    "vue": "^3.0.11"
+    "vue": "^3.0.11",
+    "vue-router": "^4.0.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vuepress/theme-vue/package.json
+++ b/packages/@vuepress/theme-vue/package.json
@@ -28,8 +28,10 @@
     "clean": "rimraf lib *.tsbuildinfo"
   },
   "dependencies": {
-    "@vuepress/core": "2.0.0-beta.14",
     "@vuepress/theme-default": "2.0.0-beta.14"
+  },
+  "devDependencies": {
+    "@vuepress/core": "2.0.0-beta.14"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vuepress/theme-vue/package.json
+++ b/packages/@vuepress/theme-vue/package.json
@@ -28,6 +28,7 @@
     "clean": "rimraf lib *.tsbuildinfo"
   },
   "dependencies": {
+    "@vuepress/core": "2.0.0-beta.14",
     "@vuepress/theme-default": "2.0.0-beta.14"
   },
   "publishConfig": {

--- a/packages/@vuepress/theme-vue/package.json
+++ b/packages/@vuepress/theme-vue/package.json
@@ -28,10 +28,8 @@
     "clean": "rimraf lib *.tsbuildinfo"
   },
   "dependencies": {
+    "@vuepress/core": "2.0.0-beta.14",
     "@vuepress/theme-default": "2.0.0-beta.14"
-  },
-  "devDependencies": {
-    "@vuepress/core": "2.0.0-beta.14"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vuepress/theme-vue/tsconfig.build.json
+++ b/packages/@vuepress/theme-vue/tsconfig.build.json
@@ -6,5 +6,8 @@
     "outDir": "./lib"
   },
   "include": ["./src"],
-  "references": [{ "path": "../theme-default/tsconfig.build.json" }]
+  "references": [
+    { "path": "../theme-default/tsconfig.build.json" },
+    { "path": "../core/tsconfig.build.json" }
+  ]
 }

--- a/packages/@vuepress/theme-vue/tsconfig.build.json
+++ b/packages/@vuepress/theme-vue/tsconfig.build.json
@@ -7,7 +7,7 @@
   },
   "include": ["./src"],
   "references": [
-    { "path": "../theme-default/tsconfig.build.json" },
-    { "path": "../core/tsconfig.build.json" }
+    { "path": "../core/tsconfig.build.json" },
+    { "path": "../theme-default/tsconfig.build.json" }
   ]
 }


### PR DESCRIPTION
1. some package used in source code, but not listed in `package.json`

| repo dir  | missing deps | used in |
| -- | -- | -- |
| @vuepress/client | vite | https://github.com/vuepress/vuepress-next/blob/e028f887ee9ee10d52abff9e37a9148139372e43/packages/%40vuepress/client/tsconfig.json#L22 |
| @vuepress/plugin-docsearch | @docsearch/react | https://github.com/vuepress/vuepress-next/blob/e028f887ee9ee10d52abff9e37a9148139372e43/packages/%40vuepress/plugin-docsearch/src/shared/types.ts#L1 |
| @vuepress/plugin-pwa-popup | vue | https://github.com/vuepress/vuepress-next/blob/e028f887ee9ee10d52abff9e37a9148139372e43/packages/%40vuepress/plugin-pwa-popup/src/client/components/PwaPopup.ts#L1 |
| @vuepress/plugin-search | vite | https://github.com/vuepress/vuepress-next/blob/e028f887ee9ee10d52abff9e37a9148139372e43/packages/%40vuepress/plugin-search/tsconfig.json#L9 |
| @vuepress/plugin-theme-data | vite, vue | https://github.com/vuepress/vuepress-next/blob/e028f887ee9ee10d52abff9e37a9148139372e43/packages/%40vuepress/plugin-theme-data/tsconfig.json#L9 https://github.com/vuepress/vuepress-next/blob/e028f887ee9ee10d52abff9e37a9148139372e43/packages/%40vuepress/plugin-theme-data/src/client/clientAppEnhance.ts#L1 |
| @vuepress/plugin-toc | vue-router | https://github.com/vuepress/vuepress-next/blob/e028f887ee9ee10d52abff9e37a9148139372e43/packages/%40vuepress/plugin-toc/src/client/components/Toc.ts#L4 |
| @vuepress/theme-vue | @vuepress/core | https://github.com/vuepress/vuepress-next/blob/e028f887ee9ee10d52abff9e37a9148139372e43/packages/%40vuepress/theme-vue/src/node/vueTheme.ts#L1 |


2. ts build order: 

`@vuepress/theme-vue` deps on `@vuepress/core`, thus `@vuepress/core` should build first