### PR TITLE
fix(plugin-search): disable default form action on Enter key

### DIFF
--- a/packages/@vuepress/plugin-search/src/client/components/SearchBox.ts
+++ b/packages/@vuepress/plugin-search/src/client/components/SearchBox.ts
@@ -120,6 +120,7 @@ export const SearchBox = defineComponent({
                   break
                 }
                 case 'Enter': {
+                  event.preventDefault()
                   goTo(focusIndex.value)
                   break
                 }


### PR DESCRIPTION
By default form element on Enter key press would try to send form request to current page, essentially reloading the page.