### PR TITLE
fix(bundler-webpack): fix devServer issues

### DIFF
--- a/packages/@vuepress/bundler-webpack/src/dev/createDevServerConfig.ts
+++ b/packages/@vuepress/bundler-webpack/src/dev/createDevServerConfig.ts
@@ -28,17 +28,17 @@ export const createDevServerConfig = (
     },
     host: app.options.host,
     hot: true,
-    onAfterSetupMiddleware: ({ app }, server) => {
+    onAfterSetupMiddleware: ({ app: expressApp }, server) => {
       // plugin hook: afterDevServer
-      options.afterDevServer?.(app, server)
+      options.afterDevServer?.(expressApp, server)
     },
-    onBeforeSetupMiddleware: ({ app }, server) => {
+    onBeforeSetupMiddleware: ({ app: expressApp }, server) => {
       // use trailing slash middleware to support vuepress routing in dev-server
       // it will be handled by most of the deployment platforms
-      app.use(trailingSlashMiddleware)
+      expressApp.use(trailingSlashMiddleware)
 
       // plugin hook: beforeDevServer
-      options.beforeDevServer?.(app, server)
+      options.beforeDevServer?.(expressApp, server)
     },
     open: app.options.open,
     port: app.options.port,

--- a/packages/@vuepress/bundler-webpack/src/dev/createDevServerConfig.ts
+++ b/packages/@vuepress/bundler-webpack/src/dev/createDevServerConfig.ts
@@ -28,17 +28,17 @@ export const createDevServerConfig = (
     },
     host: app.options.host,
     hot: true,
-    onAfterSetupMiddleware: (expressApp, server) => {
+    onAfterSetupMiddleware: ({ app }, server) => {
       // plugin hook: afterDevServer
-      options.afterDevServer?.(expressApp, server)
+      options.afterDevServer?.(app, server)
     },
-    onBeforeSetupMiddleware: (expressApp, server) => {
+    onBeforeSetupMiddleware: ({ app }, server) => {
       // use trailing slash middleware to support vuepress routing in dev-server
       // it will be handled by most of the deployment platforms
-      expressApp.use(trailingSlashMiddleware)
+      app.use(trailingSlashMiddleware)
 
       // plugin hook: beforeDevServer
-      options.beforeDevServer?.(expressApp, server)
+      options.beforeDevServer?.(app, server)
     },
     open: app.options.open,
     port: app.options.port,


### PR DESCRIPTION
See:

https://github.com/webpack/webpack-dev-server/blob/68e2f0692b8abfee8352a79948592249dfac752f/lib/Server.js#L117
https://github.com/webpack/webpack-dev-server/blob/68e2f0692b8abfee8352a79948592249dfac752f/lib/Server.js#L315
https://github.com/webpack/webpack-dev-server/blob/68e2f0692b8abfee8352a79948592249dfac752f/examples/util.js#L76-L79

The `beforeDevServer` and `afterDevServer` is not just unworkable, but throwing errors now.
