### PR TITLE
build(shared): avoid publishing tsbuildinfo

### DIFF
--- a/packages/@vuepress/shared/tsconfig.esm.json
+++ b/packages/@vuepress/shared/tsconfig.esm.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "ES2020",
     "rootDir": "./src",
-    "outDir": "./lib/esm"
+    "outDir": "./lib/esm",
+    "tsBuildInfoFile": "./tsconfig.esm.tsbuildinfo"
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
By default with our config, typescript will generate a `.tsbuildinfo` file in the parent directory of the `outDir`. However, the parent of `./lib/esm` is `./lib` which is the publish dir, we have to explicitly specify path of `.tsbuildinfo`.

This will avoid publish `.tsbuildinfo` file, which has a size of 32kb, the `lib` folder will shrink from 65.1kb to 32.0kb.  