### PR TITLE
fix(theme-default): fix nav glitch at exactly 719px screen width

### DIFF
--- a/packages/@vuepress/theme-default/src/client/components/Navbar.vue
+++ b/packages/@vuepress/theme-default/src/client/components/Navbar.vue
@@ -76,7 +76,7 @@ onMounted(() => {
     getCssValue(navbar.value, 'paddingLeft') +
     getCssValue(navbar.value, 'paddingRight')
   const handleLinksWrapWidth = (): void => {
-    if (window.innerWidth < MOBILE_DESKTOP_BREAKPOINT) {
+    if (window.innerWidth <= MOBILE_DESKTOP_BREAKPOINT) {
       linksWrapperMaxWidth.value = 0
     } else {
       linksWrapperMaxWidth.value =

--- a/packages/@vuepress/theme-default/src/client/styles/dropdown.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/dropdown.scss
@@ -150,7 +150,7 @@
   }
 }
 
-@media (min-width: $MQMobile) {
+@media (min-width: ($MQMobile + 1)) {
   .dropdown-wrapper {
     height: 1.8rem;
 


### PR DESCRIPTION
The default theme contains certain styles and logic that execute at a media query breakpoint of 719px screen width. However, there is some overlap of styling and behavior of the nav bar / sidebar at exactly 719px (i.e., behavior is as expected at 718px and 720px, but not 719px). These commits alleviate those issues.