### PR TITLE
docs(plugin-docsearch): fix wrong dependency name in config example

### DIFF
--- a/docs/reference/plugin/docsearch.md
+++ b/docs/reference/plugin/docsearch.md
@@ -161,7 +161,7 @@ If you are not using default theme, or you meet any problems when using docsearc
 module.exports = {
   plugins: [
     [
-      '@vuepress/docsearch',
+      '@vuepress/plugin-docsearch',
       {
         apiKey: '<API_KEY>',
         indexName: '<INDEX_NAME>',

--- a/docs/zh/reference/plugin/docsearch.md
+++ b/docs/zh/reference/plugin/docsearch.md
@@ -161,7 +161,7 @@
 module.exports = {
   plugins: [
     [
-      '@vuepress/docsearch',
+      '@vuepress/plugin-docsearch',
       {
         apiKey: '<API_KEY>',
         indexName: '<INDEX_NAME>',


### PR DESCRIPTION
The name `@vuepress/docsearch` listed in the document of the plugin itself was wrong. The name of the plugin in config.ts should be `@vuepress/plugin-docsearch`.

Ref: https://github.com/vuepress/vuepress-next/blob/5fc351d88f9c8e9f6c6af18674aebfd6aafd97f9/docs/.vuepress/config.ts#L155