### PR TITLE
fix(plugin-active-header-links): update active header link selector

### DIFF
--- a/docs/reference/plugin/active-header-links.md
+++ b/docs/reference/plugin/active-header-links.md
@@ -12,7 +12,7 @@ This plugin is mainly used to develop themes, and has been integrated into the d
 
 - Type: `string`
 
-- Default: `'.sidebar-item'`
+- Default: `'a.sidebar-item'`
 
 - Details:
 

--- a/docs/reference/plugin/active-header-links.md
+++ b/docs/reference/plugin/active-header-links.md
@@ -12,7 +12,7 @@ This plugin is mainly used to develop themes, and has been integrated into the d
 
 - Type: `string`
 
-- Default: `'.sidebar-link'`
+- Default: `'.sidebar-item'`
 
 - Details:
 

--- a/docs/zh/reference/plugin/active-header-links.md
+++ b/docs/zh/reference/plugin/active-header-links.md
@@ -12,7 +12,7 @@
 
 - 类型： `string`
 
-- 默认值： `'.sidebar-item'`
+- 默认值： `'a.sidebar-item'`
 
 - 详情：
 

--- a/docs/zh/reference/plugin/active-header-links.md
+++ b/docs/zh/reference/plugin/active-header-links.md
@@ -12,7 +12,7 @@
 
 - 类型： `string`
 
-- 默认值： `'.sidebar-link'`
+- 默认值： `'.sidebar-item'`
 
 - 详情：
 

--- a/packages/@vuepress/plugin-active-header-links/src/node/activeHeaderLinksPlugin.ts
+++ b/packages/@vuepress/plugin-active-header-links/src/node/activeHeaderLinksPlugin.ts
@@ -10,7 +10,7 @@ export interface ActiveHeaderLinksPluginOptions {
 
 export const activeHeaderLinksPlugin: Plugin<ActiveHeaderLinksPluginOptions> = (
   {
-    headerLinkSelector = '.sidebar-item',
+    headerLinkSelector = 'a.sidebar-item',
     headerAnchorSelector = '.header-anchor',
     delay = 200,
     offset = 5,

--- a/packages/@vuepress/plugin-active-header-links/src/node/activeHeaderLinksPlugin.ts
+++ b/packages/@vuepress/plugin-active-header-links/src/node/activeHeaderLinksPlugin.ts
@@ -10,7 +10,7 @@ export interface ActiveHeaderLinksPluginOptions {
 
 export const activeHeaderLinksPlugin: Plugin<ActiveHeaderLinksPluginOptions> = (
   {
-    headerLinkSelector = '.sidebar-link',
+    headerLinkSelector = '.sidebar-item',
     headerAnchorSelector = '.header-anchor',
     delay = 200,
     offset = 5,

--- a/packages/@vuepress/theme-default/src/node/utils/resolveActiveHeaderLinksPluginOptions.ts
+++ b/packages/@vuepress/theme-default/src/node/utils/resolveActiveHeaderLinksPluginOptions.ts
@@ -12,7 +12,7 @@ export const resolveActiveHeaderLinksPluginOptions = (
   }
 
   return {
-    headerLinkSelector: '.sidebar-item',
+    headerLinkSelector: 'a.sidebar-item',
     headerAnchorSelector: '.header-anchor',
   }
 }

--- a/packages/@vuepress/theme-default/src/node/utils/resolveActiveHeaderLinksPluginOptions.ts
+++ b/packages/@vuepress/theme-default/src/node/utils/resolveActiveHeaderLinksPluginOptions.ts
@@ -12,7 +12,7 @@ export const resolveActiveHeaderLinksPluginOptions = (
   }
 
   return {
-    headerLinkSelector: '.sidebar-link',
+    headerLinkSelector: '.sidebar-item',
     headerAnchorSelector: '.header-anchor',
   }
 }


### PR DESCRIPTION
Since the SidebarChild's template got updated from `.sidebar-link` to `.sidebar-item` in ea7c4bb, the default value for `headerLinkSelector` on the active-header-links plugin doesn't exist anymore (at least not on the default theme).