### PR TITLE
fix(theme-default): break long links on overflow (close #266)

### DIFF
--- a/packages/@vuepress/theme-default/src/client/styles/normalize.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/normalize.scss
@@ -18,6 +18,7 @@ a {
   font-weight: 500;
   color: var(--c-text-accent);
   text-decoration: none;
+  overflow-wrap: break-word;
 }
 
 p a code {


### PR DESCRIPTION
See https://github.com/vuepress/vuepress-next/issues/266