### PR TITLE
chore(theme-default): update docsBranch description

### DIFF
--- a/packages/@vuepress/theme-default/src/shared/options.ts
+++ b/packages/@vuepress/theme-default/src/shared/options.ts
@@ -174,7 +174,7 @@ export interface DefaultThemeLocaleData extends LocaleData {
   /**
    * Page meta - edit link config
    *
-   * Set this config if the branch of your docs is not 'master'
+   * Set this config if the branch of your docs is not 'main'
    */
   docsBranch?: string
 


### PR DESCRIPTION
The `docsBranch` option now defaults to `'main'`, not `'master'`