### PR TITLE
fix(theme-default): use a global isDarkMode ref

### DIFF
--- a/packages/@vuepress/theme-default/src/client/components/ToggleDarkModeButton.vue
+++ b/packages/@vuepress/theme-default/src/client/components/ToggleDarkModeButton.vue
@@ -48,14 +48,14 @@
 <script setup lang="ts">
 import {
   useDarkMode,
-  useDocumentClass,
+  useHTMLClass,
   usePrefersColorScheme,
   useThemeLocaleData,
 } from '../composables'
 
 const isDarkMode = useDarkMode()
 const themeLocale = useThemeLocaleData()
-useDocumentClass(isDarkMode)
+useHTMLClass(isDarkMode)
 usePrefersColorScheme(isDarkMode)
 
 const toggleDarkMode = (): void => {

--- a/packages/@vuepress/theme-default/src/client/components/ToggleDarkModeButton.vue
+++ b/packages/@vuepress/theme-default/src/client/components/ToggleDarkModeButton.vue
@@ -46,10 +46,11 @@
 </template>
 
 <script setup lang="ts">
-import { useDarkMode, useThemeLocaleData } from '../composables'
+import { useDarkMode, usePrefersColorScheme, useThemeLocaleData } from '../composables'
 
 const isDarkMode = useDarkMode()
 const themeLocale = useThemeLocaleData()
+usePrefersColorScheme(isDarkMode)
 
 const toggleDarkMode = (): void => {
   isDarkMode.value = !isDarkMode.value

--- a/packages/@vuepress/theme-default/src/client/components/ToggleDarkModeButton.vue
+++ b/packages/@vuepress/theme-default/src/client/components/ToggleDarkModeButton.vue
@@ -48,12 +48,14 @@
 <script setup lang="ts">
 import {
   useDarkMode,
+  useDocumentClass,
   usePrefersColorScheme,
   useThemeLocaleData,
 } from '../composables'
 
 const isDarkMode = useDarkMode()
 const themeLocale = useThemeLocaleData()
+useDocumentClass(isDarkMode)
 usePrefersColorScheme(isDarkMode)
 
 const toggleDarkMode = (): void => {

--- a/packages/@vuepress/theme-default/src/client/components/ToggleDarkModeButton.vue
+++ b/packages/@vuepress/theme-default/src/client/components/ToggleDarkModeButton.vue
@@ -48,17 +48,17 @@
 <script setup lang="ts">
 import {
   useDarkMode,
-  useHTMLClass,
+  useHtmlDarkClass,
   usePrefersColorScheme,
   useThemeLocaleData,
 } from '../composables'
 
-const isDarkMode = useDarkMode()
 const themeLocale = useThemeLocaleData()
-useHTMLClass(isDarkMode)
-usePrefersColorScheme(isDarkMode)
 
+const isDarkMode = useDarkMode()
 const toggleDarkMode = (): void => {
   isDarkMode.value = !isDarkMode.value
 }
+useHtmlDarkClass(isDarkMode)
+usePrefersColorScheme(isDarkMode)
 </script>

--- a/packages/@vuepress/theme-default/src/client/components/ToggleDarkModeButton.vue
+++ b/packages/@vuepress/theme-default/src/client/components/ToggleDarkModeButton.vue
@@ -46,7 +46,11 @@
 </template>
 
 <script setup lang="ts">
-import { useDarkMode, usePrefersColorScheme, useThemeLocaleData } from '../composables'
+import {
+  useDarkMode,
+  usePrefersColorScheme,
+  useThemeLocaleData,
+} from '../composables'
 
 const isDarkMode = useDarkMode()
 const themeLocale = useThemeLocaleData()

--- a/packages/@vuepress/theme-default/src/client/composables/index.ts
+++ b/packages/@vuepress/theme-default/src/client/composables/index.ts
@@ -1,4 +1,5 @@
 export * from './useDarkMode'
+export * from './useHTMLClass'
 export * from './useNavLink'
 export * from './usePrefersColorScheme'
 export * from './useResolveRouteWithRedirect'

--- a/packages/@vuepress/theme-default/src/client/composables/index.ts
+++ b/packages/@vuepress/theme-default/src/client/composables/index.ts
@@ -1,5 +1,6 @@
 export * from './useDarkMode'
 export * from './useNavLink'
+export * from './usePrefersColorScheme'
 export * from './useResolveRouteWithRedirect'
 export * from './useScrollPromise'
 export * from './useSidebarItems'

--- a/packages/@vuepress/theme-default/src/client/composables/index.ts
+++ b/packages/@vuepress/theme-default/src/client/composables/index.ts
@@ -1,5 +1,5 @@
 export * from './useDarkMode'
-export * from './useHTMLClass'
+export * from './useHtmlDarkClass'
 export * from './useNavLink'
 export * from './usePrefersColorScheme'
 export * from './useResolveRouteWithRedirect'

--- a/packages/@vuepress/theme-default/src/client/composables/useDarkMode.ts
+++ b/packages/@vuepress/theme-default/src/client/composables/useDarkMode.ts
@@ -1,9 +1,9 @@
 import { onMounted, onUnmounted, ref, watch } from 'vue'
 import type { Ref } from 'vue'
 
-export const useDarkMode = (): Ref<boolean> => {
-  const isDarkMode = ref(false)
+const isDarkMode = ref(false)
 
+export const useDarkMode = (): Ref<boolean> => {
   const updateDarkModeClass = (value = isDarkMode.value): void => {
     // set `class="dark"` on `<html>` element
     const htmlEl = window?.document.querySelector('html')

--- a/packages/@vuepress/theme-default/src/client/composables/useDarkMode.ts
+++ b/packages/@vuepress/theme-default/src/client/composables/useDarkMode.ts
@@ -1,34 +1,6 @@
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { ref } from 'vue'
 import type { Ref } from 'vue'
 
 const isDarkMode = ref(false)
 
-export const useDarkMode = (): Ref<boolean> => {
-  const updateDarkModeClass = (value = isDarkMode.value): void => {
-    // set `class="dark"` on `<html>` element
-    const htmlEl = window?.document.querySelector('html')
-    htmlEl?.classList.toggle('dark', value)
-  }
-
-  const mediaQuery = ref<MediaQueryList | null>(null)
-  const onMediaQueryChange = (event: MediaQueryListEvent): void => {
-    isDarkMode.value = event.matches
-  }
-
-  onMounted(() => {
-    // get `prefers-color-scheme` media query and set the initial mode
-    mediaQuery.value = window.matchMedia('(prefers-color-scheme: dark)')
-    isDarkMode.value = mediaQuery.value.matches
-
-    // watch changes
-    mediaQuery.value.addEventListener('change', onMediaQueryChange)
-    watch(isDarkMode, updateDarkModeClass, { immediate: true })
-  })
-
-  onUnmounted(() => {
-    mediaQuery.value?.removeEventListener('change', onMediaQueryChange)
-    updateDarkModeClass(false)
-  })
-
-  return isDarkMode
-}
+export const useDarkMode = (): Ref<boolean> => isDarkMode

--- a/packages/@vuepress/theme-default/src/client/composables/useHTMLClass.ts
+++ b/packages/@vuepress/theme-default/src/client/composables/useHTMLClass.ts
@@ -1,0 +1,18 @@
+import { onMounted, onUnmounted, watch } from 'vue'
+import type { Ref } from 'vue'
+
+export const useHTMLClass = (isDarkMode: Ref<boolean>): void => {
+  const updateDarkModeClass = (value = isDarkMode.value): void => {
+    // set `class="dark"` on `<html>` element
+    const htmlEl = window?.document.querySelector('html')
+    htmlEl?.classList.toggle('dark', value)
+  }
+
+  onMounted(() => {
+    watch(isDarkMode, updateDarkModeClass, { immediate: true })
+  })
+
+  onUnmounted(() => {
+    updateDarkModeClass(false)
+  })
+}

--- a/packages/@vuepress/theme-default/src/client/composables/useHtmlDarkClass.ts
+++ b/packages/@vuepress/theme-default/src/client/composables/useHtmlDarkClass.ts
@@ -1,7 +1,7 @@
 import { onMounted, onUnmounted, watch } from 'vue'
 import type { Ref } from 'vue'
 
-export const useHTMLClass = (isDarkMode: Ref<boolean>): void => {
+export const useHtmlDarkClass = (isDarkMode: Ref<boolean>): void => {
   const updateDarkModeClass = (value = isDarkMode.value): void => {
     // set `class="dark"` on `<html>` element
     const htmlEl = window?.document.querySelector('html')

--- a/packages/@vuepress/theme-default/src/client/composables/usePrefersColorScheme.ts
+++ b/packages/@vuepress/theme-default/src/client/composables/usePrefersColorScheme.ts
@@ -1,0 +1,30 @@
+import { onMounted, onUnmounted, ref, watch } from 'vue'
+import type { Ref } from 'vue'
+
+export const usePrefersColorScheme = (isDarkMode: Ref<boolean>): void => {
+  const updateDarkModeClass = (value = isDarkMode.value): void => {
+    // set `class="dark"` on `<html>` element
+    const htmlEl = window?.document.querySelector('html')
+    htmlEl?.classList.toggle('dark', value)
+  }
+
+  const mediaQuery = ref<MediaQueryList | null>(null)
+  const onMediaQueryChange = (event: MediaQueryListEvent): void => {
+    isDarkMode.value = event.matches
+  }
+
+  onMounted(() => {
+    // get `prefers-color-scheme` media query and set the initial mode
+    mediaQuery.value = window.matchMedia('(prefers-color-scheme: dark)')
+    isDarkMode.value = mediaQuery.value.matches
+
+    // watch changes
+    mediaQuery.value.addEventListener('change', onMediaQueryChange)
+    watch(isDarkMode, updateDarkModeClass, { immediate: true })
+  })
+
+  onUnmounted(() => {
+    mediaQuery.value?.removeEventListener('change', onMediaQueryChange)
+    updateDarkModeClass(false)
+  })
+}

--- a/packages/@vuepress/theme-default/src/client/composables/usePrefersColorScheme.ts
+++ b/packages/@vuepress/theme-default/src/client/composables/usePrefersColorScheme.ts
@@ -1,13 +1,7 @@
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 import type { Ref } from 'vue'
 
 export const usePrefersColorScheme = (isDarkMode: Ref<boolean>): void => {
-  const updateDarkModeClass = (value = isDarkMode.value): void => {
-    // set `class="dark"` on `<html>` element
-    const htmlEl = window?.document.querySelector('html')
-    htmlEl?.classList.toggle('dark', value)
-  }
-
   const mediaQuery = ref<MediaQueryList | null>(null)
   const onMediaQueryChange = (event: MediaQueryListEvent): void => {
     isDarkMode.value = event.matches
@@ -20,11 +14,9 @@ export const usePrefersColorScheme = (isDarkMode: Ref<boolean>): void => {
 
     // watch changes
     mediaQuery.value.addEventListener('change', onMediaQueryChange)
-    watch(isDarkMode, updateDarkModeClass, { immediate: true })
   })
 
   onUnmounted(() => {
     mediaQuery.value?.removeEventListener('change', onMediaQueryChange)
-    updateDarkModeClass(false)
   })
 }


### PR DESCRIPTION
This PR uses a global ref to make sure `useDarkMode()` still be of actual use in inherited theme development.