### PR TITLE
change preparePageComponent function

### DIFF
--- a/packages/@vuepress/core/src/app/prepare/preparePageComponent.ts
+++ b/packages/@vuepress/core/src/app/prepare/preparePageComponent.ts
@@ -7,11 +7,15 @@ export const preparePageComponent = async (
   app: App,
   page: Page
 ): Promise<void> => {
+  let  contentRendered = `<template>${page.contentRendered}</template>\n`;
+  if(page.contentRendered.indexOf("<template>") === 0 && page.contentRendered.indexOf("</template>") !== -1){
+    contentRendered  = page.contentRendered
+  }
   await app.writeTemp(
     page.componentFilePathRelative,
     [
       // take the rendered markdown content as <template>
-      `<template>${page.contentRendered}</template>\n`,
+      contentRendered,
       // hoist `<script>`, `<style>` and other custom blocks
       ...page.hoistedTags,
     ].join('\n')


### PR DESCRIPTION
在使用插件对mackdown进行自定义时，有些时候返回的md在转换为.vue文件时会在最外层包一个<template>标签，导致把script和css都包裹到了里面。所以需要加个判断，如果有<template>标签时，就不应该再在最外层生成<template>标签

When customizing the mackdown with the plugin some times the returned md is converted to. The vue file packs a <template> tag at the outermost, resulting in both script and css being wrapped inside. So you need to add a judgment that if there is a <template> tag, you should no longer generate the <template> tag at the outermost level