### PR TITLE
fix(theme-default): improve the style for non-square logo

### DIFF
--- a/packages/@vuepress/theme-default/src/client/styles/navbar.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/navbar.scss
@@ -10,7 +10,6 @@
 
   .logo {
     height: var(--navbar-line-height);
-    min-width: var(--navbar-line-height);
     margin-right: var(--navbar-padding-v);
     vertical-align: top;
   }


### PR DESCRIPTION
Currently the `min-width` css property stretches non-square logos. I'm not exactly sure if there are any cases where it is beneficial.

Before:
![image](https://user-images.githubusercontent.com/51953549/129494916-1e743fef-03ea-4bd4-8ff4-1b192484a657.png)

After:
![image](https://user-images.githubusercontent.com/51953549/129494923-d237b6c1-fff1-4e33-aa00-496f90baf661.png)
