### PR TITLE
feat(markdown): line numbers from section

### DIFF
--- a/packages/@vuepress/markdown/src/plugins/codePlugin/codePlugin.ts
+++ b/packages/@vuepress/markdown/src/plugins/codePlugin/codePlugin.ts
@@ -108,8 +108,15 @@ export const codePlugin: PluginWithOptions<CodePluginOptions> = (
     // generate line numbers
     if (useLineNumbers) {
       // generate line numbers code
+      let lineBase = token.meta?.lineStart
+      if (lineBase === undefined) {
+        lineBase = 1
+      }
       const lineNumbersCode = lines
-        .map((_, index) => `<span class="line-number">${index + 1}</span><br>`)
+        .map(
+          (_, index) =>
+            `<span class="line-number">${index + lineBase}</span><br>`
+        )
         .join('')
 
       result = `${result}<div class="line-numbers">${lineNumbersCode}</div>`


### PR DESCRIPTION
Right now, if you extract a section of external code, such as lines 10 to 13, and add line numbers, the numbers are always starting from `1`, rather than from `10`. This changes that so the line numbers are for the actual file.