### PR TITLE
feat(client): allow html title customization (close #338)

### DIFF
--- a/packages/@vuepress/client/src/app.ts
+++ b/packages/@vuepress/client/src/app.ts
@@ -104,7 +104,7 @@ export const createVueApp: CreateVueAppFunction = async () => {
   )
   const pageFrontmatter = computed(() => resolvePageFrontmatter(pageData.value))
   const pageHeadTitle = computed(() =>
-    resolvePageHeadTitle(pageData.value, siteLocaleData.value)
+    resolvePageHeadTitle.value(pageData.value, siteLocaleData.value)
   )
   const pageHead = computed(() =>
     resolvePageHead(

--- a/packages/@vuepress/client/src/injections/pageHeadTitle.ts
+++ b/packages/@vuepress/client/src/injections/pageHeadTitle.ts
@@ -1,4 +1,4 @@
-import { inject } from 'vue'
+import { inject, ref } from 'vue'
 import type { ComputedRef, InjectionKey } from 'vue'
 import type { PageData } from './pageData'
 import type { SiteLocaleData } from './siteLocaleData'
@@ -19,9 +19,12 @@ export const usePageHeadTitle = (): PageHeadTitleRef => {
 }
 
 /**
- * Title to displayed in `<head>` tag
+ * A function used for resolving the content of `head > title` tag
+ *
+ * This function is stored in a `ref`, so that users could change the
+ * function to customize the content of title tag.
  */
-export const resolvePageHeadTitle = (
-  page: PageData,
-  siteLocale: SiteLocaleData
-): PageHeadTitle => `${page.title ? `${page.title} | ` : ``}${siteLocale.title}`
+export const resolvePageHeadTitle = ref(
+  (page: PageData, siteLocale: SiteLocaleData) =>
+    `${page.title ? `${page.title} | ` : ``}${siteLocale.title}`
+)


### PR DESCRIPTION
Close #338 

This PR allows users to customize the content of `<title>` tag in this way:

```ts
// clientAppEnhance.ts
import { defineClientAppEnhance, resolvePageHeadTitle } from '@vuepress/client'

export default defineClientAppEnhance(() => {
  resolvePageHeadTitle.value = (page, site) => `${page.title} | ${site.title}`
})
```