### PR TITLE
fix(plugin-git): add HEAD into git shortlog arguments (close #205)

### DIFF
--- a/packages/@vuepress/plugin-git/src/node/utils/getContributors.ts
+++ b/packages/@vuepress/plugin-git/src/node/utils/getContributors.ts
@@ -7,7 +7,7 @@ export const getContributors = async (
 ): Promise<GitContributor[]> => {
   const { stdout } = await execa(
     'git',
-    ['--no-pager', 'shortlog', '-nes', '--', filePath],
+    ['--no-pager', 'shortlog', '-nes', 'HEAD', '--', filePath],
     {
       cwd,
       stdin: 'inherit',


### PR DESCRIPTION
Close #205

Git shortlog produces empty output in cases when HEAD is detached.

From git shortlog [docs](https://git-scm.com/docs/git-shortlog):

`
If no revisions are passed on the command line and either standard input is not a terminal or there is no current branch, git shortlog will output a summary of the log read from standard input, without reference to the current repository.
`

This PR add HEAD into shortlog arguments as revision.

Use case: At gitlab-ci job log:
```
Fetching changes...
Reinitialized existing Git repository in #doesnt_matter#
Checking out 0aac9a9b as master...
...
git status
HEAD detached at 0aac9a9
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	package.json
nothing added to commit but untracked files present (use "git add" to track)
git --no-pager shortlog -nes
npx vuepress build
info Initializing VuePress and preparing data...
- Compiling with webpack
...
```
As you can see shortlog doesnt show output