### PR TITLE
feat(theme-default): add --header-height CSS variable

### DIFF
--- a/packages/@vuepress/theme-default/src/client/styles/home.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/home.scss
@@ -1,7 +1,7 @@
 @import '_variables';
 
 .home {
-  padding: var(--navbar-height) 2rem 0;
+  padding: var(--header-height) 2rem 0;
   max-width: var(--homepage-width);
   margin: 0px auto;
   display: block;

--- a/packages/@vuepress/theme-default/src/client/styles/layout.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/layout.scss
@@ -2,7 +2,7 @@
 @import '_wrapper';
 
 .page {
-  padding-top: var(--navbar-height);
+  padding-top: var(--header-height);
   padding-left: var(--sidebar-width);
 }
 
@@ -12,7 +12,7 @@
   top: 0;
   left: 0;
   right: 0;
-  height: var(--navbar-height);
+  height: var(--header-height);
   box-sizing: border-box;
   border-bottom: 1px solid var(--c-border);
   background-color: var(--c-bg-navbar);
@@ -25,7 +25,7 @@
   position: fixed;
   z-index: 10;
   margin: 0;
-  top: var(--navbar-height);
+  top: var(--header-height);
   left: 0;
   bottom: 0;
   box-sizing: border-box;
@@ -125,8 +125,8 @@ h4,
 h5,
 h6 {
   .theme-default-content:not(.custom) > & {
-    margin-top: calc(0.5rem - var(--navbar-height));
-    padding-top: calc(1rem + var(--navbar-height));
+    margin-top: calc(0.5rem - var(--header-height));
+    padding-top: calc(1rem + var(--header-height));
     margin-bottom: 0;
 
     &:first-child {
@@ -180,7 +180,7 @@ h6 {
 @media (max-width: $MQMobile) {
   .sidebar {
     top: 0;
-    padding-top: var(--navbar-height);
+    padding-top: var(--header-height);
     transform: translateX(-100%);
   }
 

--- a/packages/@vuepress/theme-default/src/client/styles/vars.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/vars.scss
@@ -63,6 +63,7 @@
 
   // layout vars
   --navbar-height: 3.6rem;
+  --header-height: var(--navbar-height);
   --navbar-padding-v: 0.7rem;
   --navbar-padding-h: 1.5rem;
   --sidebar-width: 20rem;


### PR DESCRIPTION
This PR adds `--header-height` CSS variable which is equal to `--navbar-height` by default. When customizing `--header-height: 5.6rem`, the page contents is shifted by 2rem downwards like this

![vuepress-header-height](https://user-images.githubusercontent.com/290976/131214654-78df9bd0-a1cc-4d69-93f2-211643e53992.png)

Which then allows to use the space to customize the header, for example, adding another header above/below the existing one.

![vp-system-bar](https://user-images.githubusercontent.com/290976/131214722-09dad695-1b32-467f-b7c8-9e95c85271f6.png)

Closes https://github.com/vuepress/vuepress-next/issues/410