### PR TITLE
feat(plugin-git): take additional files in calculating git attributes (close #449)

### DIFF
--- a/docs/reference/default-theme/frontmatter.md
+++ b/docs/reference/default-theme/frontmatter.md
@@ -274,14 +274,6 @@ Frontmatter in this section will only take effect in normal pages.
 - Also see:
   - [Default Theme > Config > contributors](./config.md#contributors)
 
-### gitInclude
-
-- Type: `string[]`
-
-- Details:
-
-  This field is used by `@vuepress/plugin-git`, also see [Official Plugins Reference > Theme Development > git > Frontmatter Options](../plugin/git.md#frontmatter-options)
-
 ### sidebar
 
 - Type: `false | 'auto' | SidebarConfigArray | SidebarConfigObject`

--- a/docs/reference/default-theme/frontmatter.md
+++ b/docs/reference/default-theme/frontmatter.md
@@ -273,6 +273,15 @@ Frontmatter in this section will only take effect in normal pages.
 
 - Also see:
   - [Default Theme > Config > contributors](./config.md#contributors)
+
+### gitInclude
+
+- Type: `string[]`
+
+- Details:
+
+  This field is used by `@vuepress/plugin-git`, also see [Official Plugins Reference > Theme Development > git > Frontmatter Options](../plugin/git.md#frontmatter-options)
+
 ### sidebar
 
 - Type: `false | 'auto' | SidebarConfigArray | SidebarConfigObject`

--- a/docs/reference/plugin/git.md
+++ b/docs/reference/plugin/git.md
@@ -68,19 +68,23 @@ This plugin will significantly slow down the speed of data preparation, especial
 
   Whether to collect page contributors or not.
 
-## Frontmatter Options
+## Frontmatter
 
-This plugin accepts the `gitInclude` field of type `string[]` from Frontmatter.
+### gitInclude
 
-The `gitInclude` field should be an array of relative paths to be included in calculating `git.createdTime`, `git.updatedTime`, and `git.contributors`.
+- Type: `string[]`
 
-Example:
+- Details:
+
+  An array of relative paths to be included when calculating page data.
+
+- Example:
 
 ```md
 ---
 gitInclude:
-  - relative/path/of/file1
-  - relative/path/of/file2
+  - relative/path/to/file1
+  - relative/path/to/file2
 ---
 ```
 
@@ -110,7 +114,7 @@ export default {
 
   Unix timestamp in milliseconds of the first commit of the page.
 
-  If `gitInclude` is provided from Frontmatter, this attribute takes the minimum of the first commit timestamps of current page and the files listed in `gitInclude`.
+  This attribute would take the minimum of the first commit timestamps of the current page and the files listed in [gitInclude](#gitinclude).
 
 ### git.updatedTime
 
@@ -120,7 +124,7 @@ export default {
 
   Unix timestamp in milliseconds of the last commit of the page.
 
-  If `gitInclude` is provided from Frontmatter, this attribute takes the maximum of the last commit timestamps of current page and the files listed in `gitInclude`.
+  This attribute would take the maximum of the last commit timestamps of the current page and the files listed in [gitInclude](#gitinclude).
 
 ### git.contributors
 
@@ -138,4 +142,4 @@ interface GitContributor {
 
   The contributors information of the page.
 
-  If `gitInclude` is provided from Frontmatter, this attribute counts the overall contributors of current page and the files listed in `gitInclude`.
+  This attribute would also include contributors to the files listed in [gitInclude](#gitinclude).

--- a/docs/reference/plugin/git.md
+++ b/docs/reference/plugin/git.md
@@ -68,6 +68,22 @@ This plugin will significantly slow down the speed of data preparation, especial
 
   Whether to collect page contributors or not.
 
+## Frontmatter Options
+
+This plugin accepts the `gitInclude` field of type `string[]` from Frontmatter.
+
+The `gitInclude` field should be an array of relative paths to be included in calculating `git.createdTime`, `git.updatedTime`, and `git.contributors`.
+
+Example:
+
+```md
+---
+gitInclude:
+  - relative/path/of/file1
+  - relative/path/of/file2
+---
+```
+
 ## Page Data
 
 This plugin will add a `git` field to page data.
@@ -94,6 +110,8 @@ export default {
 
   Unix timestamp in milliseconds of the first commit of the page.
 
+  If `gitInclude` is provided from Frontmatter, this attribute takes the minimum of the first commit timestamps of current page and the files listed in `gitInclude`.
+
 ### git.updatedTime
 
 - Type: `number`
@@ -101,6 +119,8 @@ export default {
 - Details:
 
   Unix timestamp in milliseconds of the last commit of the page.
+
+  If `gitInclude` is provided from Frontmatter, this attribute takes the maximum of the last commit timestamps of current page and the files listed in `gitInclude`.
 
 ### git.contributors
 
@@ -117,3 +137,5 @@ interface GitContributor {
 - Details:
 
   The contributors information of the page.
+
+  If `gitInclude` is provided from Frontmatter, this attribute counts the overall contributors of current page and the files listed in `gitInclude`.

--- a/docs/zh/reference/default-theme/frontmatter.md
+++ b/docs/zh/reference/default-theme/frontmatter.md
@@ -274,14 +274,6 @@ features:
 - 参考：
   - [默认主题 > 配置 > contributors](./config.md#contributors)
 
-### gitInclude
-
-- 类型： `string[]`
-
-- 详情：
-
-  该值被 `@vuepress/plugin-git` 使用，详见[官方插件参考 > 主题开发 > git > Frontmatter 配置项](../plugin/git.md#frontmatter-配置项)
-
 ### sidebar
 
 - 类型： `false | 'auto' | SidebarConfigArray | SidebarConfigObject`

--- a/docs/zh/reference/default-theme/frontmatter.md
+++ b/docs/zh/reference/default-theme/frontmatter.md
@@ -274,6 +274,14 @@ features:
 - 参考：
   - [默认主题 > 配置 > contributors](./config.md#contributors)
 
+### gitInclude
+
+- 类型： `string[]`
+
+- 详情：
+
+  该值被 `@vuepress/plugin-git` 使用，详见[官方插件参考 > 主题开发 > git > Frontmatter 配置项](../plugin/git.md#frontmatter-配置项)
+
 ### sidebar
 
 - 类型： `false | 'auto' | SidebarConfigArray | SidebarConfigObject`

--- a/docs/zh/reference/plugin/git.md
+++ b/docs/zh/reference/plugin/git.md
@@ -68,6 +68,23 @@ module.exports = {
 
   是否收集页面的贡献者。
 
+
+## Frontmatter 配置项
+
+该插件可从 Frontmatter 接受类型为 `string[]` 的字段 `gitInclude`。
+
+`gitInclude` 字段应当为一个包含文件相对路径的列表，该列表中的文件会被用于计算 `git.createdTime`、`git.updatedTime`和`git.contributors`。
+
+示例：
+
+```md
+---
+gitInclude:
+  - relative/path/of/file1
+  - relative/path/of/file2
+---
+```
+
 ## 页面数据
 
 该插件会向页面数据中添加一个 `git` 字段。
@@ -94,6 +111,8 @@ export default {
 
   页面第一次提交的 Unix 毫秒时间戳。
 
+  如果 Frontmatter 提供了 `gitInclude` 字段，该值将取当前页面及 `gitInclude` 中所列文件的第一次提交的时间戳的最小值。
+
 ### git.updatedTime
 
 - 类型： `number`
@@ -101,6 +120,8 @@ export default {
 - 详情：
 
   页面最后一次提交的 Unix 毫秒时间戳。
+
+  如果 Frontmatter 提供了 `gitInclude` 字段，该值将取当前页面及 `gitInclude` 中所列文件的最后一次提交的时间戳的最大值。
 
 ### git.contributors
 
@@ -117,3 +138,5 @@ interface GitContributor {
 - 详情：
 
   页面的贡献者信息。
+
+  如果 Frontmatter 提供了 `gitInclude` 字段，该值将统计当前页面及 `gitInclude` 中所列文件的总体贡献者。

--- a/docs/zh/reference/plugin/git.md
+++ b/docs/zh/reference/plugin/git.md
@@ -69,19 +69,23 @@ module.exports = {
   是否收集页面的贡献者。
 
 
-## Frontmatter 配置项
+## Frontmatter
 
-该插件可从 Frontmatter 接受类型为 `string[]` 的字段 `gitInclude`。
+### gitInclude
 
-`gitInclude` 字段应当为一个包含文件相对路径的列表，该列表中的文件会被用于计算 `git.createdTime`、`git.updatedTime`和`git.contributors`。
+- 类型： `string[]`
 
-示例：
+- 详情：
+
+  文件相对路径组成的数组，该数组中的文件会在计算页面数据时被包含在内。
+
+- 示例：
 
 ```md
 ---
 gitInclude:
-  - relative/path/of/file1
-  - relative/path/of/file2
+  - relative/path/to/file1
+  - relative/path/to/file2
 ---
 ```
 
@@ -111,7 +115,7 @@ export default {
 
   页面第一次提交的 Unix 毫秒时间戳。
 
-  如果 Frontmatter 提供了 `gitInclude` 字段，该值将取当前页面及 `gitInclude` 中所列文件的第一次提交的时间戳的最小值。
+  该属性将取当前页面及 [gitInclude](#gitinclude) 中所列文件的第一次提交的时间戳的最小值。
 
 ### git.updatedTime
 
@@ -121,7 +125,7 @@ export default {
 
   页面最后一次提交的 Unix 毫秒时间戳。
 
-  如果 Frontmatter 提供了 `gitInclude` 字段，该值将取当前页面及 `gitInclude` 中所列文件的最后一次提交的时间戳的最大值。
+  该属性将取当前页面及 [gitInclude](#gitinclude) 中所列文件的最后一次提交的时间戳的最大值。
 
 ### git.contributors
 
@@ -139,4 +143,4 @@ interface GitContributor {
 
   页面的贡献者信息。
 
-  如果 Frontmatter 提供了 `gitInclude` 字段，该值将统计当前页面及 `gitInclude` 中所列文件的总体贡献者。
+  该属性将会包含 [gitInclude](#gitinclude) 所列文件的贡献者。

--- a/packages/@vuepress/plugin-git/package.json
+++ b/packages/@vuepress/plugin-git/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@vuepress/core": "workspace:*",
+    "@vuepress/utils": "workspace:*",
     "execa": "^5.1.1"
   },
   "publishConfig": {

--- a/packages/@vuepress/plugin-git/src/node/gitPlugin.ts
+++ b/packages/@vuepress/plugin-git/src/node/gitPlugin.ts
@@ -1,5 +1,6 @@
 import type { Page, Plugin } from '@vuepress/core'
-import type { GitPluginPageData } from './types'
+import { path } from '@vuepress/utils'
+import type { GitPluginFrontmatter, GitPluginPageData } from './types'
 import {
   checkGitRepo,
   getContributors,
@@ -36,32 +37,32 @@ export const gitPlugin =
     return {
       name: '@vuepress/plugin-git',
 
-      extendsPage: async (page: Page<GitPluginPageData>) => {
+      extendsPage: async (
+        page: Page<GitPluginPageData, GitPluginFrontmatter>
+      ) => {
         page.data.git = {}
 
         if (!isGitRepoValid || page.filePathRelative === null) {
           return
         }
 
+        const filePaths = [
+          page.filePathRelative,
+          ...(page.frontmatter.gitInclude ?? []).map((item) =>
+            path.join(page.filePathRelative, '..', item)
+          ),
+        ]
+
         if (createdTime !== false) {
-          page.data.git.createdTime = await getCreatedTime(
-            page.filePathRelative,
-            cwd
-          )
+          page.data.git.createdTime = await getCreatedTime(filePaths, cwd)
         }
 
         if (updatedTime !== false) {
-          page.data.git.updatedTime = await getUpdatedTime(
-            page.filePathRelative,
-            cwd
-          )
+          page.data.git.updatedTime = await getUpdatedTime(filePaths, cwd)
         }
 
         if (contributors !== false) {
-          page.data.git.contributors = await getContributors(
-            page.filePathRelative,
-            cwd
-          )
+          page.data.git.contributors = await getContributors(filePaths, cwd)
         }
       },
     }

--- a/packages/@vuepress/plugin-git/src/node/types.ts
+++ b/packages/@vuepress/plugin-git/src/node/types.ts
@@ -1,3 +1,7 @@
+export interface GitPluginFrontmatter {
+  gitInclude?: string[]
+}
+
 export interface GitPluginPageData {
   git: GitData
 }

--- a/packages/@vuepress/plugin-git/src/node/utils/getContributors.ts
+++ b/packages/@vuepress/plugin-git/src/node/utils/getContributors.ts
@@ -2,12 +2,12 @@ import * as execa from 'execa'
 import type { GitContributor } from '../types'
 
 export const getContributors = async (
-  filePath: string,
+  filePaths: string[],
   cwd: string
 ): Promise<GitContributor[]> => {
   const { stdout } = await execa(
     'git',
-    ['--no-pager', 'shortlog', '-nes', 'HEAD', '--', filePath],
+    ['--no-pager', 'shortlog', '-nes', 'HEAD', '--', ...filePaths],
     {
       cwd,
       stdin: 'inherit',

--- a/packages/@vuepress/plugin-git/src/node/utils/getCreatedTime.ts
+++ b/packages/@vuepress/plugin-git/src/node/utils/getCreatedTime.ts
@@ -4,16 +4,18 @@ import * as execa from 'execa'
  * Get unix timestamp in milliseconds of the first commit
  */
 export const getCreatedTime = async (
-  filePath: string,
+  filePaths: string[],
   cwd: string
 ): Promise<number> => {
   const { stdout } = await execa(
     'git',
-    ['--no-pager', 'log', '--diff-filter=A', '--format=%at', filePath],
+    ['--no-pager', 'log', '--diff-filter=A', '--format=%at', ...filePaths],
     {
       cwd,
     }
   )
 
-  return Number.parseInt(stdout, 10) * 1000
+  const timestamps = stdout.split('\n').map((item) => Number.parseInt(item, 10))
+
+  return Math.min(...timestamps) * 1000
 }

--- a/packages/@vuepress/plugin-git/src/node/utils/getCreatedTime.ts
+++ b/packages/@vuepress/plugin-git/src/node/utils/getCreatedTime.ts
@@ -15,7 +15,8 @@ export const getCreatedTime = async (
     }
   )
 
-  const timestamps = stdout.split('\n').map((item) => Number.parseInt(item, 10))
-
-  return Math.min(...timestamps) * 1000
+  return (
+    Math.min(...stdout.split('\n').map((item) => Number.parseInt(item, 10))) *
+    1000
+  )
 }

--- a/packages/@vuepress/plugin-git/src/node/utils/getUpdatedTime.ts
+++ b/packages/@vuepress/plugin-git/src/node/utils/getUpdatedTime.ts
@@ -9,13 +9,21 @@ export const getUpdatedTime = async (
 ): Promise<number> => {
   const { stdout } = await execa(
     'git',
-    ['--no-pager', 'log', '-1', '--format=%at', ...filePaths],
+    [
+      '--no-pager',
+      'log',
+      '--format=%at',
+      // if there is only one file to be included, add `-1` option
+      ...(filePaths.length > 1 ? [] : ['-1']),
+      ...filePaths,
+    ],
     {
       cwd,
     }
   )
 
-  const timestamps = stdout.split('\n').map((item) => Number.parseInt(item, 10))
-
-  return Math.max(...timestamps) * 1000
+  return (
+    Math.max(...stdout.split('\n').map((item) => Number.parseInt(item, 10))) *
+    1000
+  )
 }

--- a/packages/@vuepress/plugin-git/src/node/utils/getUpdatedTime.ts
+++ b/packages/@vuepress/plugin-git/src/node/utils/getUpdatedTime.ts
@@ -4,16 +4,18 @@ import * as execa from 'execa'
  * Get unix timestamp in milliseconds of the last commit
  */
 export const getUpdatedTime = async (
-  filePath: string,
+  filePaths: string[],
   cwd: string
 ): Promise<number> => {
   const { stdout } = await execa(
     'git',
-    ['--no-pager', 'log', '-1', '--format=%at', filePath],
+    ['--no-pager', 'log', '-1', '--format=%at', ...filePaths],
     {
       cwd,
     }
   )
 
-  return Number.parseInt(stdout, 10) * 1000
+  const timestamps = stdout.split('\n').map((item) => Number.parseInt(item, 10))
+
+  return Math.max(...timestamps) * 1000
 }

--- a/packages/@vuepress/plugin-git/tsconfig.build.json
+++ b/packages/@vuepress/plugin-git/tsconfig.build.json
@@ -6,5 +6,8 @@
     "outDir": "./lib"
   },
   "include": ["./src"],
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    { "path": "../core/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,9 +330,11 @@ importers:
   packages/@vuepress/plugin-git:
     specifiers:
       '@vuepress/core': workspace:*
+      '@vuepress/utils': workspace:*
       execa: ^5.1.1
     dependencies:
       '@vuepress/core': link:../core
+      '@vuepress/utils': link:../utils
       execa: 5.1.1
 
   packages/@vuepress/plugin-google-analytics:


### PR DESCRIPTION
close #449

This PR allows users to provide a per page frontmatter field `gitInclude` of type `string[]`.

This field is an array of relative file paths to be included in calculating git attributes `git.createdTime`, `git.updatedTime`, and `git.contributors`

## TEST

Please check this [PR](https://github.com/LucienZhang/vuepress-next/pull/2) for the test details.
