### PR TITLE
fix(theme-default): use browser default locale in last updated date

### DIFF
--- a/packages/@vuepress/theme-default/src/client/components/PageMeta.vue
+++ b/packages/@vuepress/theme-default/src/client/components/PageMeta.vue
@@ -4,12 +4,14 @@
       <NavLink class="meta-item-label" :item="editNavLink" />
     </div>
 
-    <ClientOnly>
-      <div v-if="lastUpdated" class="meta-item last-updated">
-        <span class="meta-item-label">{{ themeLocale.lastUpdatedText }}: </span>
+    
+    <div v-if="lastUpdated" class="meta-item last-updated">
+      <span class="meta-item-label">{{ themeLocale.lastUpdatedText }}: </span>
+      <ClientOnly>
         <span class="meta-item-info">{{ lastUpdated }}</span>
-      </div>
-    </ClientOnly>
+      </ClientOnly>
+    </div>
+    
 
     <div
       v-if="contributors && contributors.length"

--- a/packages/@vuepress/theme-default/src/client/components/PageMeta.vue
+++ b/packages/@vuepress/theme-default/src/client/components/PageMeta.vue
@@ -4,14 +4,12 @@
       <NavLink class="meta-item-label" :item="editNavLink" />
     </div>
 
-    
     <div v-if="lastUpdated" class="meta-item last-updated">
       <span class="meta-item-label">{{ themeLocale.lastUpdatedText }}: </span>
       <ClientOnly>
         <span class="meta-item-info">{{ lastUpdated }}</span>
       </ClientOnly>
     </div>
-    
 
     <div
       v-if="contributors && contributors.length"

--- a/packages/@vuepress/theme-default/src/client/components/PageMeta.vue
+++ b/packages/@vuepress/theme-default/src/client/components/PageMeta.vue
@@ -4,10 +4,12 @@
       <NavLink class="meta-item-label" :item="editNavLink" />
     </div>
 
-    <div v-if="lastUpdated" class="meta-item last-updated">
-      <span class="meta-item-label">{{ themeLocale.lastUpdatedText }}: </span>
-      <span class="meta-item-info">{{ lastUpdated }}</span>
-    </div>
+    <ClientOnly>
+      <div v-if="lastUpdated" class="meta-item last-updated">
+        <span class="meta-item-label">{{ themeLocale.lastUpdatedText }}: </span>
+        <span class="meta-item-info">{{ lastUpdated }}</span>
+      </div>
+    </ClientOnly>
 
     <div
       v-if="contributors && contributors.length"
@@ -99,7 +101,7 @@ const useLastUpdated = (): ComputedRef<null | string> => {
 
     const updatedDate = new Date(page.value.git?.updatedTime)
 
-    return updatedDate.toLocaleString(siteLocale.value.lang)
+    return updatedDate.toLocaleString()
   })
 }
 


### PR DESCRIPTION
Improve the "Last Updated" date by no longer using the language of the page to generate the date, but letting the browser choose the correct format according to the operating system/browser settings.

_This has emerged from a discussion in #431, although it does not "fix" the actual feature request._