### PR TITLE
fix(theme-default): display code lines as table-cell (close #459)

### DIFF
--- a/packages/@vuepress/theme-default/src/client/styles/code.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/code.scss
@@ -124,6 +124,7 @@ pre[class*='language-'] {
 .theme-default-content {
   pre,
   pre[class*='language-'] {
+    text-size-adjust: 100%;
     line-height: 1.4rem;
     padding: 1.25rem 1.5rem;
     margin: 0.85rem 0;


### PR DESCRIPTION
Fix line number and code line misalignment, close #459.

Verified works on:
- Safari iOS/iPadOS `15.0.1`
- Safari `15.1` macOS
- Chrome `94.0.4606.81` macOS
- Chrome `78.0.3904.96` Android

![Screen Shot 2021-10-08 at 17 58 46](https://user-images.githubusercontent.com/15633984/136537373-c6dc4da8-948b-41ca-8b13-9d5cf649f5fc.png)

Firefox and Edge not tested, I hopefully there’s someone could help for testing.