### PR TITLE
fix(theme-default): fix kbd color in dark mode

### DIFF
--- a/packages/@vuepress/theme-default/src/client/styles/normalize.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/normalize.scss
@@ -32,8 +32,8 @@ p a code {
 
 kbd {
   font-family: var(--font-family-code);
-  background: var(--c-bg-lighter);
   color: var(--c-text);
+  background: var(--c-bg-lighter);
   border: solid 0.15rem var(--c-border-dark);
   border-bottom: solid 0.25rem var(--c-border-dark);
   border-radius: 0.15rem;

--- a/packages/@vuepress/theme-default/src/client/styles/normalize.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/normalize.scss
@@ -33,6 +33,7 @@ p a code {
 kbd {
   font-family: var(--font-family-code);
   background: var(--c-bg-lighter);
+  color: var(--c-text);
   border: solid 0.15rem var(--c-border-dark);
   border-bottom: solid 0.25rem var(--c-border-dark);
   border-radius: 0.15rem;


### PR DESCRIPTION
fix kbd color in dark mode

if the type is warning in Custom Containers, the kbd text hard to read
the fixed color of kbd will be better

before:
![image](https://user-images.githubusercontent.com/16351105/139580159-52299609-04e9-4ffa-8682-db69dbde7626.png)


after:
![image](https://user-images.githubusercontent.com/16351105/139580141-64f6f36b-9af1-4878-afac-acf5d6cef61d.png)
