### PR TITLE
fix(theme-default): bump vueuse to avoid localstorage error (close #589)

### DIFF
--- a/packages/@vuepress/theme-default/package.json
+++ b/packages/@vuepress/theme-default/package.json
@@ -43,7 +43,7 @@
     "@vuepress/plugin-theme-data": "2.0.0-beta.32",
     "@vuepress/shared": "2.0.0-beta.32",
     "@vuepress/utils": "2.0.0-beta.32",
-    "@vueuse/core": "^7.1.2",
+    "@vueuse/core": "^7.5.3",
     "sass": "^1.44.0",
     "sass-loader": "^12.4.0",
     "vue": "^3.2.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2886,18 +2886,18 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.24.tgz#d74615e856013b17fb60b19b09d712729ad5e090"
   integrity sha512-BUgRiZCkCrqDps5aQ9av05xcge3rn092ztKIh17tHkeEFgP4zfXMQWBA2zfdoCdCEdBL26xtOv+FZYiOp9RUDA==
 
-"@vueuse/core@^7.1.2":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-7.1.2.tgz#61ab2698c725ccaf168676f34cf6f41f76f8df34"
-  integrity sha512-SLoOPfhZdNRNUkZfx+wrHj6WycWdSw2RmNS8E4ngQ2kmBoJjRarGy51/GkGdjqHQqmhuwuFoNO2WaU0yBn3ffg==
+"@vueuse/core@^7.5.3":
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-7.5.3.tgz#7e8ea430a293670f12e5052a5285cb4ef8e9c758"
+  integrity sha512-D9j5ymHFMFRXQqCp0yZJkf/bvBGiz0MrKUa364p+L8dMyd5zyq2K1JmHyvoBd4xbTFRfmQ1h878u6YE5LCkDVQ==
   dependencies:
-    "@vueuse/shared" "7.1.2"
+    "@vueuse/shared" "7.5.3"
     vue-demi "*"
 
-"@vueuse/shared@7.1.2":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-7.1.2.tgz#caee72d0669ecdb2b845349e8fea9431e50c09d6"
-  integrity sha512-AjYh4y9S5FMOoHDsysqcXY/1mpqNTrnWUD50yaaiyf+5kGWQVIpAkkjKZlYSC/NHKxxCRn0cLR4nWMzceUWewQ==
+"@vueuse/shared@7.5.3":
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-7.5.3.tgz#2a844f38e45b1002e14d8f0ab5b41221c4fb9b09"
+  integrity sha512-BJ71cxHN5VByW1S58Gl85NFJaQu93F7Vs7K/MuAKsIIuHm9PBbkR5Vxkg9ko9cBdiKVt+FNoo13BhdbA+Vwycg==
   dependencies:
     vue-demi "*"
 


### PR DESCRIPTION
PR bumps @vueuse/core from 7.1.2 to 7.5.3 and fixes problem with blank page in #589 

Affected entities:
@vueuse is only used in useDarkMode
- usePreferredDark did not change since 7.1.2
- useStorage implemented [fix for DOMException](https://github.com/vueuse/vueuse/commit/77fe0fbc3f1b3b1cae8b23bb7f1d1fc3c0fd0922)

Update should not cause any problems