### PR TITLE
feat(theme-default): fix title style when no content in custom container (close #648)

### DIFF
--- a/packages/@vuepress/theme-default/src/client/styles/custom-container.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/custom-container.scss
@@ -4,6 +4,9 @@
 
   .custom-container-title {
     font-weight: 600;
+    &:not(:only-child) {
+      margin-bottom: -0.4rem;
+    }
   }
 
   &.tip,

--- a/packages/@vuepress/theme-default/src/client/styles/custom-container.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/custom-container.scss
@@ -4,7 +4,6 @@
 
   .custom-container-title {
     font-weight: 600;
-    margin-bottom: -0.4rem;
   }
 
   &.tip,


### PR DESCRIPTION
fixed #648 
When there's no content in custom container, the title of custom container is not centered up and down, and the reason is that `margin-bottom: -0.4em;` overwrites the original `margin-bottom` of the `p` tag. So removing this style ensures that the title is center when no content in custom container. In addition, the container is not affected when it has content.

style of container without content:
![image](https://user-images.githubusercontent.com/73059627/151106468-75c83045-ebe0-4f05-a140-5d977fdcbfd8.png)

style of container with content:
![image](https://user-images.githubusercontent.com/73059627/151106527-2d0069e1-c16b-47af-bb9e-4b722db98e98.png)

