### PR TITLE
feat(theme-default): enhance header dropdown experience

### DIFF
--- a/packages/@vuepress/theme-default/src/client/components/Navbar.vue
+++ b/packages/@vuepress/theme-default/src/client/components/Navbar.vue
@@ -67,7 +67,7 @@ function getCssValue(el: HTMLElement | null, property: string): number {
 
     <div class="navbar-items-wrapper" :style="linksWrapperStyle">
       <slot name="before" />
-      <NavbarItems class="can-hide" />
+      <NavbarItems class="can-hide" is-header />
       <slot name="after" />
       <ToggleDarkModeButton v-if="enableDarkMode" />
       <NavbarSearch />

--- a/packages/@vuepress/theme-default/src/client/components/NavbarDropdown.vue
+++ b/packages/@vuepress/theme-default/src/client/components/NavbarDropdown.vue
@@ -42,7 +42,7 @@ watch(
  */
 const handleDropdown = (e): void => {
   const isTriggerByTab = e.detail === 0
-  if (isTriggerByTab) {
+  if (isTriggerByTab || props.isHeader) {
     open.value = !open.value
   } else {
     open.value = false
@@ -54,13 +54,18 @@ const isLastItemOfArray = (item: unknown, arr: unknown[]): boolean =>
 </script>
 
 <template>
-  <div class="navbar-dropdown-wrapper" :class="{ open }">
+  <div
+    class="navbar-dropdown-wrapper"
+    :class="{ open }"
+    @mouseleave="open = false"
+  >
     <button
       v-if="isHeader"
       class="navbar-dropdown-title"
       type="button"
       :aria-label="dropdownAriaLabel"
       @click="handleDropdown"
+      @mouseenter="open = true"
     >
       <span class="title">{{ item.text }}</span>
       <span class="arrow down" />
@@ -78,7 +83,7 @@ const isLastItemOfArray = (item: unknown, arr: unknown[]): boolean =>
     </button>
 
     <DropdownTransition>
-      <ul v-show="open" class="navbar-dropdown">
+      <ul v-show="isHeader ? true : open" class="navbar-dropdown">
         <li
           v-for="child in item.children"
           :key="child.text"

--- a/packages/@vuepress/theme-default/src/client/components/NavbarDropdown.vue
+++ b/packages/@vuepress/theme-default/src/client/components/NavbarDropdown.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import AutoLink from '@theme/AutoLink.vue'
 import DropdownTransition from '@theme/DropdownTransition.vue'
-import { computed, ref, toRefs, watch } from 'vue'
+import { computed, h, ref, toRefs, watch } from 'vue'
 import type { PropType } from 'vue'
 import { useRoute } from 'vue-router'
 import type { NavbarItem, ResolvedNavbarItem } from '../../shared'
@@ -9,6 +9,10 @@ import type { NavbarItem, ResolvedNavbarItem } from '../../shared'
 const props = defineProps({
   item: {
     type: Object as PropType<Exclude<ResolvedNavbarItem, NavbarItem>>,
+    required: true,
+  },
+  isHeader: {
+    type: Boolean,
     required: true,
   },
 })
@@ -52,6 +56,7 @@ const isLastItemOfArray = (item: unknown, arr: unknown[]): boolean =>
 <template>
   <div class="navbar-dropdown-wrapper" :class="{ open }">
     <button
+      v-if="isHeader"
       class="navbar-dropdown-title"
       type="button"
       :aria-label="dropdownAriaLabel"
@@ -62,6 +67,7 @@ const isLastItemOfArray = (item: unknown, arr: unknown[]): boolean =>
     </button>
 
     <button
+      v-else
       class="navbar-dropdown-title-mobile"
       type="button"
       :aria-label="dropdownAriaLabel"

--- a/packages/@vuepress/theme-default/src/client/components/NavbarDropdown.vue
+++ b/packages/@vuepress/theme-default/src/client/components/NavbarDropdown.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import AutoLink from '@theme/AutoLink.vue'
 import DropdownTransition from '@theme/DropdownTransition.vue'
-import { computed, h, ref, toRefs, watch } from 'vue'
+import { computed, ref, toRefs, watch } from 'vue'
 import type { PropType } from 'vue'
 import { useRoute } from 'vue-router'
 import type { NavbarItem, ResolvedNavbarItem } from '../../shared'

--- a/packages/@vuepress/theme-default/src/client/components/NavbarItems.vue
+++ b/packages/@vuepress/theme-default/src/client/components/NavbarItems.vue
@@ -10,6 +10,14 @@ import type { NavbarGroup, NavbarItem, ResolvedNavbarItem } from '../../shared'
 import { useNavLink, useThemeLocaleData } from '../composables'
 import { resolveRepoType } from '../utils'
 
+defineProps({
+  isHeader: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+})
+
 /**
  * Get navbar config of select language dropdown
  */
@@ -147,7 +155,7 @@ const navbarLinks = computed(() => [
 <template>
   <nav v-if="navbarLinks.length" class="navbar-items">
     <div v-for="item in navbarLinks" :key="item.text" class="navbar-item">
-      <NavbarDropdown v-if="item.children" :item="item" />
+      <NavbarDropdown v-if="item.children" :item="item" :is-header="isHeader" />
       <AutoLink v-else :item="item" />
     </div>
   </nav>

--- a/packages/@vuepress/theme-default/src/client/styles/navbar-dropdown.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/navbar-dropdown.scss
@@ -154,18 +154,16 @@
   .navbar-dropdown-wrapper {
     height: 1.8rem;
 
-    &:hover .navbar-dropdown,
     &.open .navbar-dropdown {
-      // override the inline style.
-      display: block !important;
-    }
-
-    &.open:blur {
-      display: none;
+      opacity: 1;
+      transform: none;
     }
 
     .navbar-dropdown {
-      display: none;
+      display: block;
+      opacity: 0;
+      transform: translateY(-0.5rem);
+      transition: opacity 0.3s ease, transform 0.3s ease;
       // Avoid height shaked by clicking
       height: auto !important;
       box-sizing: border-box;


### PR DESCRIPTION
This pull request introduces different transition behaviors for header and aside navbars:

- header: transform & opacity, just like https://vuejs.org
- aside: collapse (DropdownTransition)