### PR TITLE
feat(markdown): support vPre in inline code (close #683)

### DIFF
--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -294,7 +294,7 @@ const onePlusTwoPlusThree = {{ 1 + 2 + 3 }}
 ::: tip
 This v-pre extension is supported by our built-in plugin.
 
-Config reference: [markdown.code.vPre](../reference/config.md#markdown-vpre)
+Config reference: [markdown.code.vPre.block](../reference/config.md#markdown-code-vpre-block)
 :::
 
 ### Import Code Blocks

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -422,7 +422,7 @@ You should not configure it unless you understand what it is for.
 You can disable it if you want to implement them in client side. For example, [Prismjs Line Highlight](https://prismjs.com/plugins/line-highlight/) or [Prismjs Line Numbers](https://prismjs.com/plugins/line-numbers/).
 :::
 
-#### markdown.code.vPre
+#### markdown.code.vPre.block
 
 - Type: `boolean`
 
@@ -430,7 +430,20 @@ You can disable it if you want to implement them in client side. For example, [P
 
 - Details:
 
-  Enable the `v-pre` directive on `<pre>` tag or not.
+  Add `v-pre` directive to `<pre>` tag of code block or not.
+
+- Also see:
+  - [Guide > Markdown > Syntax Extensions > Code Blocks > Wrap with v-pre](../guide/markdown.md#wrap-with-v-pre)
+
+#### markdown.code.vPre.inline
+
+- Type: `boolean`
+
+- Default: `true`
+
+- Details:
+
+  Add `v-pre` directive to `<code>` tag of inline code or not.
 
 - Also see:
   - [Guide > Markdown > Syntax Extensions > Code Blocks > Wrap with v-pre](../guide/markdown.md#wrap-with-v-pre)

--- a/docs/zh/guide/markdown.md
+++ b/docs/zh/guide/markdown.md
@@ -297,7 +297,7 @@ const onePlusTwoPlusThree = {{ 1 + 2 + 3 }}
 ::: tip
 v-pre 扩展是由我们的内置插件支持的。
 
-配置参考： [markdown.code.vPre](../reference/config.md#markdown-vpre)
+配置参考： [markdown.code.vPre.block](../reference/config.md#markdown-code-vpre-block)
 :::
 
 ### 导入代码块

--- a/docs/zh/reference/config.md
+++ b/docs/zh/reference/config.md
@@ -421,7 +421,7 @@ VuePress 在构建过程中会在输出目录下生成临时文件，因此该�
 如果你想要在客户端来实现这些功能时，可以禁用该配置项。比如使用 [Prismjs Line Highlight](https://prismjs.com/plugins/line-highlight/) 或者 [Prismjs Line Numbers](https://prismjs.com/plugins/line-numbers/)。
 :::
 
-#### markdown.code.vPre
+#### markdown.code.vPre.block
 
 - 类型： `boolean`
 
@@ -429,7 +429,20 @@ VuePress 在构建过程中会在输出目录下生成临时文件，因此该�
 
 - 详情：
 
-  是否在 `<pre>` 标签上添加 `v-pre` 指令。
+  是否在代码块的 `<pre>` 标签上添加 `v-pre` 指令。
+
+- 参考：
+  - [指南 > Markdown > 语法扩展 > 代码块 > 添加 v-pre](../guide/markdown.md#添加-v-pre)
+
+#### markdown.code.vPre.inline
+
+- 类型： `boolean`
+
+- 默认值： `true`
+
+- 详情：
+
+  是否在行内代码的 `<code>` 标签上添加 `v-pre` 指令。
 
 - 参考：
   - [指南 > Markdown > 语法扩展 > 代码块 > 添加 v-pre](../guide/markdown.md#添加-v-pre)

--- a/packages/@vuepress/markdown/__tests__/plugins/__snapshots__/codePlugin.spec.ts.snap
+++ b/packages/@vuepress/markdown/__tests__/plugins/__snapshots__/codePlugin.spec.ts.snap
@@ -212,7 +212,7 @@ function bar () {
 </div>
 `;
 
-exports[`@vuepress/markdown > plugins > codePlugin :v-pre / :no-v-pre should work properly if \`vPre\` is disabled by default 1`] = `
+exports[`@vuepress/markdown > plugins > codePlugin :v-pre / :no-v-pre should work properly if \`vPre.block\` is disabled by default 1`] = `
 <div class="language-text ext-text line-numbers-mode"><pre class="language-text"><code>Raw text
 </code></pre>
   <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br></div>
@@ -287,7 +287,7 @@ function bar () {
 </div>
 `;
 
-exports[`@vuepress/markdown > plugins > codePlugin :v-pre / :no-v-pre should work properly if \`vPre\` is enabled by default 1`] = `
+exports[`@vuepress/markdown > plugins > codePlugin :v-pre / :no-v-pre should work properly if \`vPre.block\` is enabled by default 1`] = `
 <div class="language-text ext-text line-numbers-mode"><pre v-pre class="language-text"><code>Raw text
 </code></pre>
   <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br></div>
@@ -395,6 +395,7 @@ const baz = () =&gt; {
 </code></pre>
   <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br><span class="line-number">2</span><br><span class="line-number">3</span><br><span class="line-number">4</span><br><span class="line-number">5</span><br><span class="line-number">6</span><br><span class="line-number">7</span><br><span class="line-number">8</span><br><span class="line-number">9</span><br></div>
 </div>
+<p><code v-pre>{{ inlineCode }}</code></p>
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin plugin options should disable \`lineNumbers\` 1`] = `
@@ -437,6 +438,7 @@ const baz = () =&gt; {
     <div class="highlight-line">&nbsp;</div><br><br><br><br>
   </div>
 </div>
+<p><code v-pre>{{ inlineCode }}</code></p>
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin plugin options should disable \`preWrapper\` 1`] = `
@@ -461,9 +463,10 @@ const baz = () =&gt; {
   return 2048
 }
 </code></pre>
+<p><code v-pre>{{ inlineCode }}</code></p>
 `;
 
-exports[`@vuepress/markdown > plugins > codePlugin plugin options should disable \`vPre\` 1`] = `
+exports[`@vuepress/markdown > plugins > codePlugin plugin options should disable \`vPre.block\` 1`] = `
 <div class="language-text ext-text line-numbers-mode"><pre class="language-text"><code>Raw text
 </code></pre>
   <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br></div>
@@ -507,6 +510,101 @@ const baz = () =&gt; {
   </div>
   <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br><span class="line-number">2</span><br><span class="line-number">3</span><br><span class="line-number">4</span><br><span class="line-number">5</span><br><span class="line-number">6</span><br><span class="line-number">7</span><br><span class="line-number">8</span><br><span class="line-number">9</span><br></div>
 </div>
+<p><code v-pre>{{ inlineCode }}</code></p>
+`;
+
+exports[`@vuepress/markdown > plugins > codePlugin plugin options should disable \`vPre.inline\` 1`] = `
+<div class="language-text ext-text line-numbers-mode"><pre v-pre class="language-text"><code>Raw text
+</code></pre>
+  <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br></div>
+</div>
+<div class="language-typescript ext-ts line-numbers-mode"><pre v-pre class="language-typescript"><code>const foo = 'foo'
+
+function bar () {
+  return 1024
+}
+</code></pre>
+  <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br><span class="line-number">2</span><br><span class="line-number">3</span><br><span class="line-number">4</span><br><span class="line-number">5</span><br></div>
+</div>
+<div class="language-typescript ext-ts line-numbers-mode"><pre v-pre class="language-typescript"><code>const foo = 'foo'
+
+function bar () {
+  return 1024
+}
+</code></pre>
+  <div class="highlight-lines">
+    <div class="highlight-line">&nbsp;</div>
+    <div class="highlight-line">&nbsp;</div><br><br><br>
+  </div>
+  <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br><span class="line-number">2</span><br><span class="line-number">3</span><br><span class="line-number">4</span><br><span class="line-number">5</span><br></div>
+</div>
+<div class="language-typescript ext-ts line-numbers-mode"><pre v-pre class="language-typescript"><code>const foo = 'foo'
+
+function bar () {
+  return 1024
+}
+
+const baz = () =&gt; {
+  return 2048
+}
+</code></pre>
+  <div class="highlight-lines">
+    <div class="highlight-line">&nbsp;</div>
+    <div class="highlight-line">&nbsp;</div>
+    <div class="highlight-line">&nbsp;</div>
+    <div class="highlight-line">&nbsp;</div>
+    <div class="highlight-line">&nbsp;</div><br><br><br><br>
+  </div>
+  <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br><span class="line-number">2</span><br><span class="line-number">3</span><br><span class="line-number">4</span><br><span class="line-number">5</span><br><span class="line-number">6</span><br><span class="line-number">7</span><br><span class="line-number">8</span><br><span class="line-number">9</span><br></div>
+</div>
+<p><code>{{ inlineCode }}</code></p>
+`;
+
+exports[`@vuepress/markdown > plugins > codePlugin plugin options should disable \`vPre.inline\` and \`vPre.block\` 1`] = `
+<div class="language-text ext-text line-numbers-mode"><pre class="language-text"><code>Raw text
+</code></pre>
+  <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br></div>
+</div>
+<div class="language-typescript ext-ts line-numbers-mode"><pre class="language-typescript"><code>const foo = 'foo'
+
+function bar () {
+  return 1024
+}
+</code></pre>
+  <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br><span class="line-number">2</span><br><span class="line-number">3</span><br><span class="line-number">4</span><br><span class="line-number">5</span><br></div>
+</div>
+<div class="language-typescript ext-ts line-numbers-mode"><pre class="language-typescript"><code>const foo = 'foo'
+
+function bar () {
+  return 1024
+}
+</code></pre>
+  <div class="highlight-lines">
+    <div class="highlight-line">&nbsp;</div>
+    <div class="highlight-line">&nbsp;</div><br><br><br>
+  </div>
+  <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br><span class="line-number">2</span><br><span class="line-number">3</span><br><span class="line-number">4</span><br><span class="line-number">5</span><br></div>
+</div>
+<div class="language-typescript ext-ts line-numbers-mode"><pre class="language-typescript"><code>const foo = 'foo'
+
+function bar () {
+  return 1024
+}
+
+const baz = () =&gt; {
+  return 2048
+}
+</code></pre>
+  <div class="highlight-lines">
+    <div class="highlight-line">&nbsp;</div>
+    <div class="highlight-line">&nbsp;</div>
+    <div class="highlight-line">&nbsp;</div>
+    <div class="highlight-line">&nbsp;</div>
+    <div class="highlight-line">&nbsp;</div><br><br><br><br>
+  </div>
+  <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br><span class="line-number">2</span><br><span class="line-number">3</span><br><span class="line-number">4</span><br><span class="line-number">5</span><br><span class="line-number">6</span><br><span class="line-number">7</span><br><span class="line-number">8</span><br><span class="line-number">9</span><br></div>
+</div>
+<p><code>{{ inlineCode }}</code></p>
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin plugin options should enable \`lineNumbers\` according to number of code lines 1`] = `
@@ -552,6 +650,7 @@ const baz = () =&gt; {
   </div>
   <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br><span class="line-number">2</span><br><span class="line-number">3</span><br><span class="line-number">4</span><br><span class="line-number">5</span><br><span class="line-number">6</span><br><span class="line-number">7</span><br><span class="line-number">8</span><br><span class="line-number">9</span><br></div>
 </div>
+<p><code v-pre>{{ inlineCode }}</code></p>
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin plugin options should process code fences with default options 1`] = `
@@ -598,6 +697,7 @@ const baz = () =&gt; {
   </div>
   <div class="line-numbers" aria-hidden="true"><span class="line-number">1</span><br><span class="line-number">2</span><br><span class="line-number">3</span><br><span class="line-number">4</span><br><span class="line-number">5</span><br><span class="line-number">6</span><br><span class="line-number">7</span><br><span class="line-number">8</span><br><span class="line-number">9</span><br></div>
 </div>
+<p><code v-pre>{{ inlineCode }}</code></p>
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin syntax highlighting should work if highlighted code is not wrapped with \`<pre>\` 1`] = `

--- a/packages/@vuepress/markdown/__tests__/plugins/codePlugin.spec.ts
+++ b/packages/@vuepress/markdown/__tests__/plugins/codePlugin.spec.ts
@@ -37,6 +37,8 @@ const baz = () => {
   return 2048
 }
 ${codeFence}
+
+${codeFence}{{ inlineCode }}${codeFence}
 `
 
     it('should process code fences with default options', () => {
@@ -77,9 +79,34 @@ ${codeFence}
       expect(md.render(source)).toMatchSnapshot()
     })
 
-    it('should disable `vPre`', () => {
+    it('should disable `vPre.block`', () => {
       const md = MarkdownIt().use(codePlugin, {
-        vPre: false,
+        vPre: {
+          block: false,
+          inline: true,
+        },
+      })
+
+      expect(md.render(source)).toMatchSnapshot()
+    })
+
+    it('should disable `vPre.inline`', () => {
+      const md = MarkdownIt().use(codePlugin, {
+        vPre: {
+          block: true,
+          inline: false,
+        },
+      })
+
+      expect(md.render(source)).toMatchSnapshot()
+    })
+
+    it('should disable `vPre.inline` and `vPre.block`', () => {
+      const md = MarkdownIt().use(codePlugin, {
+        vPre: {
+          block: false,
+          inline: false,
+        },
       })
 
       expect(md.render(source)).toMatchSnapshot()
@@ -267,17 +294,21 @@ function bar () {
 ${codeFence}
 `
 
-    it('should work properly if `vPre` is enabled by default', () => {
+    it('should work properly if `vPre.block` is enabled by default', () => {
       const md = MarkdownIt().use(codePlugin, {
-        vPre: true,
+        vPre: {
+          block: true,
+        },
       })
 
       expect(md.render(source)).toMatchSnapshot()
     })
 
-    it('should work properly if `vPre` is disabled by default', () => {
+    it('should work properly if `vPre.block` is disabled by default', () => {
       const md = MarkdownIt().use(codePlugin, {
-        vPre: false,
+        vPre: {
+          block: false,
+        },
       })
 
       expect(md.render(source)).toMatchSnapshot()

--- a/packages/@vuepress/markdown/src/plugins/codePlugin/codePlugin.ts
+++ b/packages/@vuepress/markdown/src/plugins/codePlugin/codePlugin.ts
@@ -29,9 +29,19 @@ export interface CodePluginOptions {
   preWrapper?: boolean
 
   /**
-   * Add `v-pre` directive to `<pre>` tag or not
+   * Add `v-pre` directive or not
    */
-  vPre?: boolean
+  vPre?: {
+    /**
+     * Add `v-pre` directive to `<pre>` tag of code block or not
+     */
+    block?: boolean
+
+    /**
+     * Add `v-pre` directive `<code>` tag of inline code or not
+     */
+    inline?: boolean
+  }
 }
 
 /**
@@ -43,7 +53,7 @@ export const codePlugin: PluginWithOptions<CodePluginOptions> = (
     highlightLines = true,
     lineNumbers = true,
     preWrapper = true,
-    vPre = true,
+    vPre: { block: vPreBlock = true, inline: vPreInline = true } = {},
   }: CodePluginOptions = {}
 ): void => {
   // override default fence renderer
@@ -68,7 +78,7 @@ export const codePlugin: PluginWithOptions<CodePluginOptions> = (
       : `<pre class="${languageClass}"><code>${code}</code></pre>`
 
     // resolve v-pre mark from token info
-    const useVPre = resolveVPre(info) ?? vPre
+    const useVPre = resolveVPre(info) ?? vPreBlock
     if (useVPre) {
       result = `<pre v-pre${result.slice('<pre'.length)}`
     }
@@ -120,5 +130,13 @@ export const codePlugin: PluginWithOptions<CodePluginOptions> = (
     }">${result}</div>`
 
     return result
+  }
+
+  if (vPreInline) {
+    const rawInlineCodeRule = md.renderer.rules.code_inline!
+    md.renderer.rules.code_inline = (tokens, idx, options, env, slf) => {
+      const result = rawInlineCodeRule(tokens, idx, options, env, slf)
+      return `<code v-pre${result.slice('<code'.length)}`
+    }
   }
 }

--- a/packages/@vuepress/markdown/src/plugins/codePlugin/codePlugin.ts
+++ b/packages/@vuepress/markdown/src/plugins/codePlugin/codePlugin.ts
@@ -38,7 +38,7 @@ export interface CodePluginOptions {
     block?: boolean
 
     /**
-     * Add `v-pre` directive `<code>` tag of inline code or not
+     * Add `v-pre` directive to `<code>` tag of inline code or not
      */
     inline?: boolean
   }


### PR DESCRIPTION
update vPre option in code plugin

BREAKING CHANGES: `vPre` option  changed from `boolean` to `'always' | 'block' | 'inline' | 'never'`