### PR TITLE
feat(core): support frontmatter.redirectFrom

### DIFF
--- a/docs/reference/frontmatter.md
+++ b/docs/reference/frontmatter.md
@@ -184,6 +184,14 @@ permalinkPattern: :year/:month/:day/:slug.html
   - [Frontmatter > permalink](#permalink)
   - [Node API > Page Properties > permalink](./node-api.md#permalink)
 
+## redirectFrom
+
+- Type: `string[]`
+
+- Details:
+
+  Sometimes we need to modify the structure of the document, resulting in old links inaccessible to user. `redirectFrom` provides a way to specify a set of legacy paths. User accessing one of those paths will be automatically redirected to the current page.
+
 ## routeMeta
 
 - Type: `Record<string, unknown>`

--- a/docs/zh/reference/frontmatter.md
+++ b/docs/zh/reference/frontmatter.md
@@ -184,6 +184,14 @@ permalinkPattern: :year/:month/:day/:slug.html
   - [Frontmatter > permalink](#permalink)
   - [Node API > Page 属性 > permalink](./node-api.md#permalink)
 
+## redirectFrom
+
+- Type: `string[]`
+
+- Details:
+
+  有时我们需要修改文档的结构，导致旧的链接无法访问。`redirectFrom` 提供了一种描述了过时路径的方式。当用户访问这些路径中的任意一个时，会被自动重定向到当前页面。
+
 ## routeMeta
 
 - 类型： `Record<string, unknown>`

--- a/packages/@vuepress/core/src/app/prepare/preparePagesRoutes.ts
+++ b/packages/@vuepress/core/src/app/prepare/preparePagesRoutes.ts
@@ -20,21 +20,22 @@ const transformPageToRouteItem = ({
   pathInferred,
   filePathRelative,
   routeMeta,
+  frontmatter,
 }: Page): RouteItem => {
   // paths that should redirect to this page, use set to dedupe
   const redirectsSet = new Set<string>()
 
   // redirect from decoded path
-  addPath(path);
+  addPath(path)
   function addPath(path) {
-    redirectsSet.add(decodeURI(path));
+    redirectsSet.add(decodeURI(path))
     if (path.endsWith('/')) {
       // redirect from index path
-      redirectsSet.add(path + 'index.html');
+      redirectsSet.add(path + 'index.html')
     }
     else {
       // redirect from the path that does not end with `.html`
-      redirectsSet.add(path.replace(/.html$/, ''));
+      redirectsSet.add(path.replace(/.html$/, ''))
     }
   }
 
@@ -54,7 +55,7 @@ const transformPageToRouteItem = ({
   // redirect from frontmatter
   if (frontmatter.redirectFrom) {
     for (const path of frontmatter.redirectFrom) {
-      addPath(path);
+      addPath(path)
     }
   }
 

--- a/packages/@vuepress/core/src/app/prepare/preparePagesRoutes.ts
+++ b/packages/@vuepress/core/src/app/prepare/preparePagesRoutes.ts
@@ -32,8 +32,7 @@ const transformPageToRouteItem = ({
     if (path.endsWith('/')) {
       // redirect from index path
       redirectsSet.add(path + 'index.html')
-    }
-    else {
+    } else {
       // redirect from the path that does not end with `.html`
       redirectsSet.add(path.replace(/.html$/, ''))
     }

--- a/packages/@vuepress/core/src/app/prepare/preparePagesRoutes.ts
+++ b/packages/@vuepress/core/src/app/prepare/preparePagesRoutes.ts
@@ -27,15 +27,15 @@ const transformPageToRouteItem = ({
   // redirect from decoded path
   addPath(path);
   function addPath(path) {
-      redirectsSet.add(decodeURI(path));
-      if (path.endsWith('/')) {
-          // redirect from index path
-          redirectsSet.add(path + 'index.html');
-      }
-      else {
-          // redirect from the path that does not end with `.html`
-          redirectsSet.add(path.replace(/.html$/, ''));
-      }
+    redirectsSet.add(decodeURI(path));
+    if (path.endsWith('/')) {
+      // redirect from index path
+      redirectsSet.add(path + 'index.html');
+    }
+    else {
+      // redirect from the path that does not end with `.html`
+      redirectsSet.add(path.replace(/.html$/, ''));
+    }
   }
 
   // redirect from inferred path

--- a/packages/@vuepress/core/src/app/prepare/preparePagesRoutes.ts
+++ b/packages/@vuepress/core/src/app/prepare/preparePagesRoutes.ts
@@ -25,14 +25,17 @@ const transformPageToRouteItem = ({
   const redirectsSet = new Set<string>()
 
   // redirect from decoded path
-  redirectsSet.add(decodeURI(path))
-
-  if (path.endsWith('/')) {
-    // redirect from index path
-    redirectsSet.add(path + 'index.html')
-  } else {
-    // redirect from the path that does not end with `.html`
-    redirectsSet.add(path.replace(/.html$/, ''))
+  addPath(path);
+  function addPath(path) {
+      redirectsSet.add(decodeURI(path));
+      if (path.endsWith('/')) {
+          // redirect from index path
+          redirectsSet.add(path + 'index.html');
+      }
+      else {
+          // redirect from the path that does not end with `.html`
+          redirectsSet.add(path.replace(/.html$/, ''));
+      }
   }
 
   // redirect from inferred path
@@ -46,6 +49,13 @@ const transformPageToRouteItem = ({
     const filenamePath = ensureLeadingSlash(filePathRelative)
     redirectsSet.add(filenamePath)
     redirectsSet.add(encodeURI(filenamePath))
+  }
+
+  // redirect from frontmatter
+  if (frontmatter.redirectFrom) {
+    for (const path of frontmatter.redirectFrom) {
+      addPath(path);
+    }
   }
 
   // avoid redirect from the page path itself

--- a/packages/@vuepress/core/src/app/prepare/preparePagesRoutes.ts
+++ b/packages/@vuepress/core/src/app/prepare/preparePagesRoutes.ts
@@ -25,9 +25,7 @@ const transformPageToRouteItem = ({
   // paths that should redirect to this page, use set to dedupe
   const redirectsSet = new Set<string>()
 
-  // redirect from decoded path
-  addPath(path)
-  function addPath(path) {
+  function addPath(path): void {
     redirectsSet.add(decodeURI(path))
     if (path.endsWith('/')) {
       // redirect from index path
@@ -37,6 +35,9 @@ const transformPageToRouteItem = ({
       redirectsSet.add(path.replace(/.html$/, ''))
     }
   }
+
+  // redirect from decoded path
+  addPath(path)
 
   // redirect from inferred path
   if (pathInferred !== null) {

--- a/packages/@vuepress/shared/src/types/page.ts
+++ b/packages/@vuepress/shared/src/types/page.ts
@@ -77,6 +77,7 @@ export type PageFrontmatter<
   layout?: string
   permalink?: string
   permalinkPattern?: string
+  redirectFrom?: string[]
   routeMeta?: Record<string, unknown>
   title?: string
 }


### PR DESCRIPTION
In many scenarios, developers have modified the structure of the document, resulting in old links inaccessible. We need a way to specify a set of legacy paths for each file. When the user visits the corresponding path, he will be automatically redirected to the new path.