### PR TITLE
fix: @vuepress/client dependency in vuepress-vite

### DIFF
--- a/packages/vuepress-vite/package.json
+++ b/packages/vuepress-vite/package.json
@@ -39,7 +39,7 @@
     "@vuepress/theme-default": "workspace:*"
   },
   "peerDependencies": {
-    "@vuepress/client": "^2.0.0-beta.42",
+    "@vuepress/client": "workspace:*",
     "vue": "^3.2.33"
   }
 }


### PR DESCRIPTION
The dependency "vuepress-vite -> @vuepress/client" should not be hardcoded (as far as I understand), but always use the in-workspace version (i.e. "workspace:*")