### PR TITLE
fix: show the search modal correctly

### DIFF
--- a/packages/@vuepress/plugin-docsearch/src/client/components/Docsearch.ts
+++ b/packages/@vuepress/plugin-docsearch/src/client/components/Docsearch.ts
@@ -9,6 +9,8 @@ import { useDocsearchShim } from '../composables'
 
 import '@docsearch/css'
 
+import '../styles/docsearch.css'
+
 export const Docsearch = defineComponent({
   name: 'Docsearch',
 

--- a/packages/@vuepress/plugin-docsearch/src/client/styles/docsearch.css
+++ b/packages/@vuepress/plugin-docsearch/src/client/styles/docsearch.css
@@ -1,0 +1,5 @@
+@media (max-width: 750px) {
+  .DocSearch-Container{
+    position: fixed;
+  }
+}


### PR DESCRIPTION
the search modal shows incorrectly in mobile when the page was scrolled down, so i found the problem what it cause.
```css
@media (max-width: 750px) {
  .DocSearch-Container{
    position: absolute;
  }
}
```
👇👇👇
```css
@media (max-width: 750px) {
  .DocSearch-Container{
    position: fixed;
  }
}
```
keeping the default css can solve this problem.  
![GIF 2022-5-7 11-01-06.gif](https://s2.loli.net/2022/05/07/MoYsICQVnq25Fph.gif)
