### PR TITLE
chore: update docs to 2.0.0-beta.45

### DIFF
--- a/docs/reference/default-theme/config.md
+++ b/docs/reference/default-theme/config.md
@@ -1,9 +1,9 @@
 # Config
 
-<NpmBadge package="@vuepress/theme-default" />
+<NpmBadge package="@vuepress" />
 
 ```js
-const { defaultTheme } = require('@vuepress/theme-default')
+const { defaultTheme } = require('vuepress')
 
 module.exports = {
   theme: defaultTheme({


### PR DESCRIPTION
- update docs `@vuepress/theme-default` => `vuepress`
- Ref: https://github.com/vuepress/vuepress-next/blob/main/CHANGELOG.md#200-beta40-2022-04-25

---

I notice those two pages are different:
- https://v2.vuepress.vuejs.org/reference/default-theme/config.html#config
- https://v2.vuepress.vuejs.org/guide/theme.html#default-theme

maybe I miss something, if I am wrong, just ignore this PR :))

Thanks !