### PR TITLE
Fix: issue-913 Remove header anchor when scrolling to page top

### DIFF
--- a/packages/@vuepress/plugin-active-header-links/src/client/composables/useActiveHeaderLinks.ts
+++ b/packages/@vuepress/plugin-active-header-links/src/client/composables/useActiveHeaderLinks.ts
@@ -53,6 +53,17 @@ export const useActiveHeaderLinks = ({
     // check if we have reached page bottom
     // notice the `scrollBottom` might not be exactly equal to `scrollHeight`, so we add offset here
     const isAtPageBottom = Math.abs(scrollHeight - scrollBottom) < offset
+    
+    // check if we have reached page bottom
+    const isAtPageTop = Math.abs(scrollTop - 0) < offset
+        // if we have reached page Top, replace current route hash with empty string
+        if (isAtPageTop) {
+            // replace current route hash with empty string
+            replaceWithoutScrollBehavior(router, {
+                hash: '',
+                force: true,
+            })
+        }
 
     for (let i = 0; i < existedHeaderAnchors.length; i++) {
       const anchor = existedHeaderAnchors[i]

--- a/packages/@vuepress/plugin-active-header-links/src/client/composables/useActiveHeaderLinks.ts
+++ b/packages/@vuepress/plugin-active-header-links/src/client/composables/useActiveHeaderLinks.ts
@@ -54,7 +54,7 @@ export const useActiveHeaderLinks = ({
     // notice the `scrollBottom` might not be exactly equal to `scrollHeight`, so we add offset here
     const isAtPageBottom = Math.abs(scrollHeight - scrollBottom) < offset
     
-    // check if we have reached page bottom
+    // check if we have reached page top
     const isAtPageTop = Math.abs(scrollTop - 0) < offset
     // if we have reached page Top, replace current route hash with empty string
     if (isAtPageTop) {

--- a/packages/@vuepress/plugin-active-header-links/src/client/composables/useActiveHeaderLinks.ts
+++ b/packages/@vuepress/plugin-active-header-links/src/client/composables/useActiveHeaderLinks.ts
@@ -21,6 +21,34 @@ export const useActiveHeaderLinks = ({
   const page = usePageData()
 
   const setActiveRouteHash = (): void => {
+    // get current scrollTop
+    const scrollTop = Math.max(
+      window.scrollY,
+      document.documentElement.scrollTop,
+      document.body.scrollTop
+    )
+    // check if we are at page top
+    const isAtPageTop = Math.abs(scrollTop - 0) < offset
+    if (isAtPageTop) {
+      // replace current route hash with empty string
+      replaceWithoutScrollBehavior(router, {
+        hash: '',
+        force: true,
+      })
+      return
+    }
+
+    // get current scrollBottom
+    const scrollBottom = window.innerHeight + scrollTop
+    // get the total scroll length of current page
+    const scrollHeight = Math.max(
+      document.documentElement.scrollHeight,
+      document.body.scrollHeight
+    )
+    // check if we have reached page bottom
+    // notice the `scrollBottom` might not be exactly equal to `scrollHeight`, so we add offset here
+    const isAtPageBottom = Math.abs(scrollHeight - scrollBottom) < offset
+
     // get all header links
     const headerLinks: HTMLAnchorElement[] = Array.from(
       document.querySelectorAll(headerLinkSelector)
@@ -33,37 +61,6 @@ export const useActiveHeaderLinks = ({
     const existedHeaderAnchors = headerAnchors.filter((anchor) =>
       headerLinks.some((link) => link.hash === anchor.hash)
     )
-
-    // get current scrollTop
-    const scrollTop = Math.max(
-      window.pageYOffset,
-      document.documentElement.scrollTop,
-      document.body.scrollTop
-    )
-
-    // get current scrollBottom
-    const scrollBottom = window.innerHeight + scrollTop
-
-    // get the total scroll length of current page
-    const scrollHeight = Math.max(
-      document.documentElement.scrollHeight,
-      document.body.scrollHeight
-    )
-
-    // check if we have reached page bottom
-    // notice the `scrollBottom` might not be exactly equal to `scrollHeight`, so we add offset here
-    const isAtPageBottom = Math.abs(scrollHeight - scrollBottom) < offset
-    
-    // check if we have reached page top
-    const isAtPageTop = Math.abs(scrollTop - 0) < offset
-    // if we have reached page Top, replace current route hash with empty string
-    if (isAtPageTop) {
-        // replace current route hash with empty string
-        replaceWithoutScrollBehavior(router, {
-            hash: '',
-            force: true,
-        })
-    }
 
     for (let i = 0; i < existedHeaderAnchors.length; i++) {
       const anchor = existedHeaderAnchors[i]

--- a/packages/@vuepress/plugin-active-header-links/src/client/composables/useActiveHeaderLinks.ts
+++ b/packages/@vuepress/plugin-active-header-links/src/client/composables/useActiveHeaderLinks.ts
@@ -56,14 +56,14 @@ export const useActiveHeaderLinks = ({
     
     // check if we have reached page bottom
     const isAtPageTop = Math.abs(scrollTop - 0) < offset
-        // if we have reached page Top, replace current route hash with empty string
-        if (isAtPageTop) {
-            // replace current route hash with empty string
-            replaceWithoutScrollBehavior(router, {
-                hash: '',
-                force: true,
-            })
-        }
+    // if we have reached page Top, replace current route hash with empty string
+    if (isAtPageTop) {
+        // replace current route hash with empty string
+        replaceWithoutScrollBehavior(router, {
+            hash: '',
+            force: true,
+        })
+    }
 
     for (let i = 0; i < existedHeaderAnchors.length; i++) {
       const anchor = existedHeaderAnchors[i]


### PR DESCRIPTION
## Description

Linked with this feature request issue https://github.com/vuepress/vuepress-next/issues/913

## Note

The back-to-top or manual scrolling would both trigger the 'scroll' event. 
So, we could directly modify the function "useActiveHeaderLinks".

We only need to check whether we are at the top of the page.
If we are at the top of the page, replace the 'hash' of the router with an empty string.
```javascript
    // check if we have reached page top
    const isAtPageTop = Math.abs(scrollTop - 0) < offset
    // if we have reached page Top, replace current route hash with empty string
    if (isAtPageTop) {
        // replace current route hash with empty string
        replaceWithoutScrollBehavior(router, {
            hash: '',
            force: true,
        })
    }
```

I think the 'isAtPageTop' checking is necessary.  If we use a reset strategy, i.e. replacing the 'hash' of the router with an empty string at the beginning of the function "useActiveHeaderLinks" without the 'isAtPageTop' checking, we would have another issue: if we scroll to the middle part of a place between two anchors where no anchor is active according to the isActive-checking condition, the 'hash' of the router would also be reset.  

The remained question is whether the current offset suits the 'isAtPageTop' checking condition?