### PR TITLE
feat(theme-default): headings anchor should not be selectable

### DIFF
--- a/packages/@vuepress/theme-default/src/client/styles/normalize.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/normalize.scss
@@ -129,6 +129,7 @@ a.header-anchor {
   padding-right: 0.23em;
   margin-top: 0.125em;
   opacity: 0;
+  user-select: none;
 
   &:hover {
     text-decoration: none;

--- a/packages/@vuepress/theme-default/src/client/styles/page.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/page.scss
@@ -8,6 +8,10 @@
   .theme-default-content {
     @include content_wrapper;
     padding-top: 0;
+
+    .header-anchor {
+      user-select: none;
+    }
   }
 }
 

--- a/packages/@vuepress/theme-default/src/client/styles/page.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/page.scss
@@ -8,10 +8,6 @@
   .theme-default-content {
     @include content_wrapper;
     padding-top: 0;
-
-    .header-anchor {
-      user-select: none;
-    }
   }
 }
 


### PR DESCRIPTION
### Description

Currently, when users select the page content to copy & paste the text, it also selects the headings **#** anchors.

### Steps to recreate

* Select the page content with your mouse or using keyboard (CRTL + A)
* Copy the text
* Paste it to an external document

You will see that all content headings (H1-H6) has a **#** prefix.

### Solution

This PR removes the headings anchor-selection by defining the anchors as not selectable (`user-select: none;`).
