### PR TITLE
Escape double-quotes in head tag attribute values

### DIFF
--- a/packages/@vuepress/client/src/setupUpdateHead.ts
+++ b/packages/@vuepress/client/src/setupUpdateHead.ts
@@ -81,7 +81,7 @@ export const queryHeadTag = ([
   const attrsSelector = Object.entries(attrs)
     .map(([key, value]) => {
       if (isString(value)) {
-        return `[${key}="${value}"]`
+        return `[${key}=${JSON.stringify(value)}]`
       }
       if (value === true) {
         return `[${key}]`


### PR DESCRIPTION
To reproduce the bug:

```
// config.js
module.exports = {
  head: [
    ['script', {
       src: 'https://something.com/foo.js',
       'data-payload': '{"token": "hello"}',  // Use an attribute value with a JSON-encoded string.
    }],
  ],
```

You should run into the following error:

```
Document.querySelectorAll: 'head > script[src="https://something.com/foo.js"][data-payload="{"token": "hello"}"]' is not a valid selector
```

The problem is that the `data-payload` value is a JSON-encoded string, which requires double quotes, but the current implementation simply wraps the CSS selector for that call to `querySelectorAll` in double quotes and calls it a day. Use `JSON.stringify` instead. Since `value` is known to be a string in this context, this should always work (tested locally manually).