### PR TITLE
add `alternate` head for i18n

### DIFF
--- a/packages/@vuepress/client/src/resolvers.ts
+++ b/packages/@vuepress/client/src/resolvers.ts
@@ -46,7 +46,8 @@ export const resolvers = reactive({
   resolvePageHead: (
     headTitle: PageHeadTitle,
     frontmatter: PageFrontmatter,
-    siteLocale: SiteLocaleData
+    siteLocale: SiteLocaleData,
+    alternate: PageHead
   ): PageHead => {
     const description = isString(frontmatter.description)
       ? frontmatter.description
@@ -56,6 +57,7 @@ export const resolvers = reactive({
       ...siteLocale.head,
       ['title', {}, headTitle],
       ['meta', { name: 'description', content: description }],
+      ...alternate,
     ]
     return dedupeHead(head)
   },
@@ -70,6 +72,45 @@ export const resolvers = reactive({
     siteLocale: SiteLocaleData
   ): PageHeadTitle =>
     `${page.title ? `${page.title} | ` : ``}${siteLocale.title}`,
+
+  /**
+   * Resolve alternate head tags
+   */
+  resolveAlternateHead: (
+    siteData: SiteData,
+    routePath: string,
+    routeLocale: RouteLocale
+  ): PageHead => {
+    const { url, locales } = siteData
+    const alternate = []
+    const localeKeys = Object.keys(locales)
+    if (localeKeys.length <= 1) {
+      return alternate
+    }
+    for (const localeKey in locales) {
+      const localeValue = locales[localeKey]
+      alternate.push([
+        'link',
+        {
+          rel: 'alternate',
+          href: `${url || ''}${routePath.replace(routeLocale, localeKey)}`,
+          hreflang: localeValue.lang,
+        },
+      ])
+    }
+
+    const defaultLocaleKey = localeKeys[0]
+    alternate.push([
+      'link',
+      {
+        rel: 'alternate',
+        href: `${url || ''}${routePath.replace(routeLocale, defaultLocaleKey)}`,
+        hreflang: 'x-default',
+      },
+    ])
+
+    return alternate
+  },
 
   /**
    * Resolve page language from page data

--- a/packages/@vuepress/client/src/setupGlobalComputed.ts
+++ b/packages/@vuepress/client/src/setupGlobalComputed.ts
@@ -69,11 +69,19 @@ export const setupGlobalComputed = (
   const pageHeadTitle = computed(() =>
     resolvers.resolvePageHeadTitle(pageData.value, siteLocaleData.value)
   )
+  const alternateHead = computed(() =>
+    resolvers.resolveAlternateHead(
+      siteData.value,
+      router.currentRoute.value.path,
+      routeLocale.value
+    )
+  )
   const pageHead = computed(() =>
     resolvers.resolvePageHead(
       pageHeadTitle.value,
       pageFrontmatter.value,
-      siteLocaleData.value
+      siteLocaleData.value,
+      alternateHead.value
     )
   )
   const pageLang = computed(() => resolvers.resolvePageLang(pageData.value))

--- a/packages/@vuepress/core/__tests__/app/resolveAppOptions.spec.ts
+++ b/packages/@vuepress/core/__tests__/app/resolveAppOptions.spec.ts
@@ -13,6 +13,7 @@ describe('core > app > resolveAppOptions', () => {
       })
     ).toEqual({
       base: '/',
+      url: '',
       lang: 'en-US',
       title: '',
       description: '',

--- a/packages/@vuepress/core/src/app/resolveAppOptions.ts
+++ b/packages/@vuepress/core/src/app/resolveAppOptions.ts
@@ -7,6 +7,7 @@ import type { AppConfig, AppOptions } from '../types'
 export const resolveAppOptions = ({
   // site config
   base = '/',
+  url = '',
   lang = 'en-US',
   title = '',
   description = '',
@@ -41,6 +42,7 @@ export const resolveAppOptions = ({
   theme,
 }: AppConfig): AppOptions => ({
   base,
+  url,
   lang,
   title,
   description,

--- a/packages/@vuepress/core/src/app/resolveAppSiteData.ts
+++ b/packages/@vuepress/core/src/app/resolveAppSiteData.ts
@@ -7,6 +7,7 @@ import type { AppOptions, SiteData } from '../types'
  */
 export const resolveAppSiteData = (options: AppOptions): SiteData => ({
   base: options.base,
+  url: options.url,
   lang: options.lang,
   title: options.title,
   description: options.description,

--- a/packages/@vuepress/shared/src/types/site.ts
+++ b/packages/@vuepress/shared/src/types/site.ts
@@ -15,6 +15,12 @@ export interface SiteData extends SiteLocaleData {
   base: '/' | `/${string}/`
 
   /**
+   * The url of the site, containing the scheme and host
+   * @example https://example.com
+   */
+  url: string
+
+  /**
    * Specify locales for i18n support
    *
    * It will override the root-level site data in different subpath


### PR DESCRIPTION
## Background

According to Google's guidance, a website with multi languages or for multi region should use `hreflang`.

- <https://developers.google.com/search/docs/advanced/crawling/managing-multi-regional-sites>
- <https://developers.google.com/search/docs/advanced/crawling/localized-versions>

The method is to add `link`s to `<head>`:

```html
<link rel="alternate" hreflang="lang_code" href="url_of_page" />
```

For each language version, a `link` should be added. And the url must contains schema and hostname, `//example.com/foo` or `/foo` is not valid.

## Changes

- add a `url` to site data, for example `https://example.com`
- add `link`s to head when there exists more than one `locale`s
- the first `locale` will be the default language

## More discussion

- the name `url` comes from `hexo` config, but may be not so accurate
- the place of option: should it appear in `locale` options? (to support the situation: different language pages under different domain names)

