### PR TITLE
fix(plugin-docsearch): fix plugin-docsearch can not successful navigate

### DIFF
--- a/packages/@vuepress/plugin-docsearch/src/client/composables/useDocsearchShim.ts
+++ b/packages/@vuepress/plugin-docsearch/src/client/composables/useDocsearchShim.ts
@@ -50,7 +50,7 @@ export const useDocsearchShim = (): Partial<DocSearchProps> => {
     navigator: {
       // when pressing Enter without metaKey
       navigate: ({ itemUrl }) => {
-        router.push(itemUrl)
+        router.push(new URL(itemUrl).pathname)
       },
     },
 


### PR DESCRIPTION
The fix can not use the key of `Enter` to select the search result to navigate successfully.
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/30423976/182931115-8e202fc9-3951-4912-80b3-82cc2d9cc322.png">
