### PR TITLE
Add `r` to `$codeLang` variable

### DIFF
--- a/packages/@vuepress/theme-default/src/client/styles/_variables.scss
+++ b/packages/@vuepress/theme-default/src/client/styles/_variables.scss
@@ -7,5 +7,5 @@ $MQMobileNarrow: 419px !default;
 
 // code languages
 $codeLang: 'c' 'cpp' 'cs' 'css' 'dart' 'docker' 'fs' 'go' 'html' 'java' 'js'
-  'json' 'kt' 'less' 'makefile' 'md' 'php' 'py' 'rb' 'rs' 'sass' 'scss' 'sh'
-  'styl' 'ts' 'toml' 'vue' 'yml' !default;
+  'json' 'kt' 'less' 'makefile' 'md' 'php' 'py' 'r' 'rb' 'rs' 'sass' 'scss'
+  'sh' 'styl' 'ts' 'toml' 'vue' 'yml' !default;


### PR DESCRIPTION
While using `VuePress` to build the documentation for my `R` package, I noticed that the language ID is missing from the top right corner (i.e., as seen below).

<img width="742" alt="CleanShot 2022-08-08 at 16 20 49@2x" src="https://user-images.githubusercontent.com/20051042/183440154-6079744d-739a-42d4-9d43-3ae81468e069.png">

I can't recall seeing any mention in the official documentation on how to address this. The culprit seems to be `r` missing from the `$codeLang` `SCSS` variable:

https://github.com/vuepress/vuepress-next/blob/100fac96717fb5bf22c976f5c3ab7f454e821742/packages/%40vuepress/theme-default/src/client/styles/code.scss#L250-L256

After updating `$codeLang` to

```scss
$codeLang: 'c' 'cpp' 'cs' 'css' 'dart' 'docker' 'fs' 'go' 'html' 'java' 'js'
  'json' 'kt' 'less' 'makefile' 'md' 'php' 'py' 'rb' 'rs' 'sass' 'scss' 'sh'
  'styl' 'ts' 'toml' 'vue' 'yml' !default;
```

the language ID seems to be properly displayed, i.e.:

<img width="742" alt="CleanShot 2022-08-08 at 16 27 14@2x" src="https://user-images.githubusercontent.com/20051042/183441557-4565ac2b-31c0-4c71-a936-afaabcd7590e.png">


