### PR TITLE
feat(core): add hook before initialize

### DIFF
--- a/docs/reference/plugin-api.md
+++ b/docs/reference/plugin-api.md
@@ -323,6 +323,14 @@ export default {
 
 ## Lifecycle Hooks
 
+### beforeInitialize
+
+- Type: `(app: App) => void | Promise<void>`
+
+- Details:
+
+  This hook will be invoked before VuePress app starts initializing, which sets `app.pages` and `app.markdown`.
+
 ### onInitialized
 
 - Type: `(app: App) => void | Promise<void>`

--- a/packages/@vuepress/core/__tests__/pluginApi/createHookQueue.spec.ts
+++ b/packages/@vuepress/core/__tests__/pluginApi/createHookQueue.spec.ts
@@ -14,6 +14,7 @@ app.markdown = createMarkdown()
 describe('core > pluginApi > createHookQueue', () => {
   describe('common', () => {
     const hookNames = [
+      'beforeInitialize',
       'onInitialized',
       'onPrepared',
       'onWatched',

--- a/packages/@vuepress/core/src/app/appInit.ts
+++ b/packages/@vuepress/core/src/app/appInit.ts
@@ -18,6 +18,9 @@ export const appInit = async (app: App): Promise<void> => {
   // hooks in plugins will take effect after `registerHooks()`
   app.pluginApi.registerHooks()
 
+  // plugin hook: beforeInitialize
+  await app.pluginApi.hooks.beforeInitialize.process(app)
+
   // create markdown
   app.markdown = await resolveAppMarkdown(app)
 

--- a/packages/@vuepress/core/src/pluginApi/createPluginApiHooks.ts
+++ b/packages/@vuepress/core/src/pluginApi/createPluginApiHooks.ts
@@ -3,6 +3,7 @@ import { createHookQueue } from './createHookQueue'
 
 export const createPluginApiHooks = (): PluginApi['hooks'] => ({
   // life cycle hooks
+  beforeInitialize: createHookQueue('beforeInitialize'),
   onInitialized: createHookQueue('onInitialized'),
   onPrepared: createHookQueue('onPrepared'),
   onWatched: createHookQueue('onWatched'),

--- a/packages/@vuepress/core/src/types/pluginApi/hooks.ts
+++ b/packages/@vuepress/core/src/types/pluginApi/hooks.ts
@@ -47,6 +47,7 @@ export type ReturnObjectHook = Hook<
  * List of hooks
  */
 export interface Hooks {
+  beforeInitialize: LifeCycleHook
   onInitialized: LifeCycleHook
   onPrepared: LifeCycleHook
   onWatched: LifeCycleHook<[watchers: Closable[], restart: () => Promise<void>]>


### PR DESCRIPTION
This adds a lifecycle hook before the app is initialized. I'm not sure if you want this implemented, 

I want to change/update locale data through a plugin, but I noticed the changes are not being reflected in the pages array in other plugins. I checked out the source and discovered this is because the earliest hook, `onInitialized` happens after pages are resolved. So I added another hook right before it.

I've updated the unit tests and tested it with my use case and it works like a charm.