### PR TITLE
feat(client):  modify the rendering of tab titles

### DIFF
--- a/packages/client/src/resolvers.ts
+++ b/packages/client/src/resolvers.ts
@@ -69,7 +69,9 @@ export const resolvers = reactive({
     page: PageData,
     siteLocale: SiteLocaleData
   ): PageHeadTitle =>
-    `${page.title ? `${page.title}` : ``}${siteLocale.title ? ` | ${siteLocale.title}` : ``}`,
+    `${page.title ? `${page.title}` : ``}${
+      siteLocale.title ? ` | ${siteLocale.title}` : ``
+    }`,
 
   /**
    * Resolve page language from page data

--- a/packages/client/src/resolvers.ts
+++ b/packages/client/src/resolvers.ts
@@ -69,7 +69,7 @@ export const resolvers = reactive({
     page: PageData,
     siteLocale: SiteLocaleData
   ): PageHeadTitle =>
-    `${page.title ? `${page.title} | ` : ``}${siteLocale.title}`,
+    `${page.title ? `${page.title}` : ``}${siteLocale.title ? ` | ${siteLocale.title}` : ``}`,
 
   /**
    * Resolve page language from page data


### PR DESCRIPTION
When the user does not configure the default title, expect to see `DOCS NAME` on the tab instead of `DOCS NAME |`.