### PR TITLE
Preloading critical style-sheets for improved performance 🚤  

### DIFF
--- a/ecosystem/theme-default/templates/build.html
+++ b/ecosystem/theme-default/templates/build.html
@@ -23,8 +23,8 @@
 			}
     </script>
     <!--vuepress-ssr-head-->
-    <!--vuepress-ssr-resources-->
     <!--vuepress-ssr-styles-->
+    <!--vuepress-ssr-resources-->
   </head>
   <body>
     <div id="app"><!--vuepress-ssr-app--></div>

--- a/packages/bundler-vite/src/build/renderPageStyles.ts
+++ b/packages/bundler-vite/src/build/renderPageStyles.ts
@@ -12,7 +12,8 @@ export const renderPageStyles = ({
   outputCssAsset: OutputAsset | undefined
 }): string =>
   outputCssAsset
-    ? `
-    <link rel="preload" href="${app.options.base}${outputCssAsset.fileName}" as="style" />
-    <link rel="stylesheet" href="${app.options.base}${outputCssAsset.fileName}" />`
+    ? [
+        `<link rel="preload" href="${app.options.base}${outputCssAsset.fileName}" as="style" />`,
+        `<link rel="stylesheet" href="${app.options.base}${outputCssAsset.fileName}" />`,
+      ].join('')
     : ''

--- a/packages/bundler-vite/src/build/renderPageStyles.ts
+++ b/packages/bundler-vite/src/build/renderPageStyles.ts
@@ -12,5 +12,7 @@ export const renderPageStyles = ({
   outputCssAsset: OutputAsset | undefined
 }): string =>
   outputCssAsset
-    ? `<link rel="stylesheet" href="${app.options.base}${outputCssAsset.fileName}">`
+    ? `
+    <link rel="preload" href="${app.options.base}${outputCssAsset.fileName}" as="style" />
+    <link rel="stylesheet" href="${app.options.base}${outputCssAsset.fileName}" />`
     : ''

--- a/packages/bundler-webpack/src/build/renderPageStyles.ts
+++ b/packages/bundler-webpack/src/build/renderPageStyles.ts
@@ -18,6 +18,8 @@ export const renderPageStyles = ({
   [...initialFilesMeta, ...pageClientFilesMeta]
     .filter(({ type }) => type === 'style')
     .map(
-      ({ file }) => `<link rel="stylesheet" href="${app.options.base}${file}">`
+      ({ file }) => `
+      <link rel="preload" href="${app.options.base}${file}" as="style" />
+      <link rel="stylesheet" href="${app.options.base}${file}" />`
     )
     .join('')

--- a/packages/bundler-webpack/src/build/renderPageStyles.ts
+++ b/packages/bundler-webpack/src/build/renderPageStyles.ts
@@ -17,9 +17,8 @@ export const renderPageStyles = ({
   // notice here we put async CSS files after initial CSS files
   [...initialFilesMeta, ...pageClientFilesMeta]
     .filter(({ type }) => type === 'style')
-    .map(
-      ({ file }) => `
-      <link rel="preload" href="${app.options.base}${file}" as="style" />
-      <link rel="stylesheet" href="${app.options.base}${file}" />`
-    )
+    .flatMap(({ file }) => [
+      `<link rel="preload" href="${app.options.base}${file}" as="style" />`,
+      `<link rel="stylesheet" href="${app.options.base}${file}" />`,
+    ])
     .join('')

--- a/packages/client/templates/build.html
+++ b/packages/client/templates/build.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="generator" content="VuePress {{ version }}">
     <!--vuepress-ssr-head-->
-    <!--vuepress-ssr-resources-->
     <!--vuepress-ssr-styles-->
+    <!--vuepress-ssr-resources-->
   </head>
   <body>
     <div id="app"><!--vuepress-ssr-app--></div>

--- a/packages/client/templates/build.html
+++ b/packages/client/templates/build.html
@@ -2,7 +2,7 @@
 <html lang="{{ lang }}">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="generator" content="VuePress {{ version }}">
     <!--vuepress-ssr-head-->
     <!--vuepress-ssr-styles-->

--- a/packages/client/templates/build.html
+++ b/packages/client/templates/build.html
@@ -2,7 +2,7 @@
 <html lang="{{ lang }}">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="generator" content="VuePress {{ version }}">
     <!--vuepress-ssr-head-->
     <!--vuepress-ssr-styles-->


### PR DESCRIPTION
This is inspired from `Next.js`.
 1) [Preload critical stylesheets to improve loading speed](https://web.dev/preload-critical-assets/).
 2) Loading CSS top of other prefetches and preloads for faster CSS renders.

_Sorry if I made any mistakes :(_