### PR TITLE
Adding `as` attribute for  `<link rel="prefetch" />`  :)

### DIFF
--- a/packages/bundler-vite/src/build/renderPagePrefetchLinks.ts
+++ b/packages/bundler-vite/src/build/renderPagePrefetchLinks.ts
@@ -39,7 +39,7 @@ export const renderPagePrefetchLinks = ({
       if (shouldPrefetch !== true && !shouldPrefetch(item, type)) {
         return ''
       }
-      return `<link rel="prefetch" href="${app.options.base}${item}">`
+      return `<link rel="prefetch" href="${app.options.base}${item}" as="${type}" />`
     })
     .join('')
 }

--- a/packages/bundler-webpack/src/build/renderPagePrefetchLinks.ts
+++ b/packages/bundler-webpack/src/build/renderPagePrefetchLinks.ts
@@ -32,7 +32,7 @@ export const renderPagePrefetchLinks = ({
       if (shouldPrefetch !== true && !shouldPrefetch(file, type)) {
         return ''
       }
-      return `<link rel="prefetch" href="${app.options.base}${file}">`
+      return `<link rel="prefetch" href="${app.options.base}${file}" as="${type}" />`
     })
     .join('')
 }


### PR DESCRIPTION
Adding `as` attribute for  `<link rel="prefetch" />`.

Reference -: https://web.dev/link-prefetch/#how-to-implement-rel=prefetch