### PR TITLE
build: update shiki

### DIFF
--- a/ecosystem/plugin-shiki/package.json
+++ b/ecosystem/plugin-shiki/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@vuepress/core": "workspace:*",
-    "shiki": "^0.10.1"
+    "shiki": "^0.11.1"
   },
   "publishConfig": {
     "access": "public"

--- a/ecosystem/plugin-shiki/src/node/shikiPlugin.ts
+++ b/ecosystem/plugin-shiki/src/node/shikiPlugin.ts
@@ -9,7 +9,7 @@ export type ShikiPluginOptions = Pick<HighlighterOptions, 'theme' | 'langs'>
 
 export const shikiPlugin = ({
   theme = 'nord',
-  langs = [],
+  langs,
 }: ShikiPluginOptions = {}): Plugin => ({
   name: '@vuepress/plugin-shiki',
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,10 +304,10 @@ importers:
   ecosystem/plugin-shiki:
     specifiers:
       '@vuepress/core': workspace:*
-      shiki: ^0.10.1
+      shiki: ^0.11.1
     dependencies:
       '@vuepress/core': link:../../packages/core
-      shiki: 0.10.1
+      shiki: 0.11.1
 
   ecosystem/plugin-theme-data:
     specifiers:
@@ -6857,8 +6857,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  /jsonc-parser/3.0.0:
-    resolution: {integrity: sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==}
+  /jsonc-parser/3.2.0:
+    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
     dev: false
 
   /jsonfile/6.1.0:
@@ -8520,12 +8520,12 @@ packages:
     resolution: {integrity: sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==}
     dev: true
 
-  /shiki/0.10.1:
-    resolution: {integrity: sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==}
+  /shiki/0.11.1:
+    resolution: {integrity: sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==}
     dependencies:
-      jsonc-parser: 3.0.0
+      jsonc-parser: 3.2.0
       vscode-oniguruma: 1.6.2
-      vscode-textmate: 5.2.0
+      vscode-textmate: 6.0.0
     dev: false
 
   /side-channel/1.0.4:
@@ -9535,8 +9535,8 @@ packages:
     resolution: {integrity: sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==}
     dev: false
 
-  /vscode-textmate/5.2.0:
-    resolution: {integrity: sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==}
+  /vscode-textmate/6.0.0:
+    resolution: {integrity: sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==}
     dev: false
 
   /vue-demi/0.13.1_vue@3.2.38:


### PR DESCRIPTION
In my project, I use a custom theme for syntax highlighting. I can't update `shiki` version because it is not compatible with the old version