### PR TITLE
fix(plugin-search): triggering hotkey while typing

### DIFF
--- a/ecosystem/plugin-search/src/client/composables/useHotKeys.ts
+++ b/ecosystem/plugin-search/src/client/composables/useHotKeys.ts
@@ -1,8 +1,7 @@
 import { onBeforeUnmount, onMounted } from 'vue'
 import type { Ref } from 'vue'
 import type { HotKeyOptions } from '../../shared/index.js'
-import { isKeyMatched } from '../utils/index.js'
-import { isFocusingTextControl } from '../utils/isFocusingTextControl.js'
+import { isFocusingTextControl, isKeyMatched } from '../utils/index.js'
 
 export const useHotKeys = ({
   input,

--- a/ecosystem/plugin-search/src/client/composables/useHotKeys.ts
+++ b/ecosystem/plugin-search/src/client/composables/useHotKeys.ts
@@ -17,8 +17,8 @@ export const useHotKeys = ({
     if (
       // key matches
       isKeyMatched(event, hotKeys.value) &&
-      // event does not come from search box
-      !input.value.contains(event.target as Node) &&
+      // event does not come from the search box itself or
+      // user isn't focusing (and thus perhaps typing in) a text control
       !isFocusingTextControl(event.target as EventTarget)
     ) {
       event.preventDefault()

--- a/ecosystem/plugin-search/src/client/composables/useHotKeys.ts
+++ b/ecosystem/plugin-search/src/client/composables/useHotKeys.ts
@@ -2,6 +2,7 @@ import { onBeforeUnmount, onMounted } from 'vue'
 import type { Ref } from 'vue'
 import type { HotKeyOptions } from '../../shared/index.js'
 import { isKeyMatched } from '../utils/index.js'
+import { isFocusingTextControl } from '../utils/isFocusingTextControl.js'
 
 export const useHotKeys = ({
   input,
@@ -18,7 +19,8 @@ export const useHotKeys = ({
       // key matches
       isKeyMatched(event, hotKeys.value) &&
       // event does not come from search box
-      !input.value.contains(event.target as Node)
+      !input.value.contains(event.target as Node) &&
+      !isFocusingTextControl(event.target as EventTarget)
     ) {
       event.preventDefault()
       input.value.focus()

--- a/ecosystem/plugin-search/src/client/utils/index.ts
+++ b/ecosystem/plugin-search/src/client/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './isFocusingTextControl.js'
 export * from './isKeyMatched.js'
 export * from './isQueryMatched.js'

--- a/ecosystem/plugin-search/src/client/utils/isFocusingTextControl.ts
+++ b/ecosystem/plugin-search/src/client/utils/isFocusingTextControl.ts
@@ -1,7 +1,7 @@
 /**
  * Determines whether the user is currently focusing a text control.
  * In this case, the search plugin shouldn’t hijack any hotkeys because
- * the user might be typing into a text field, using type-ahead search 
+ * the user might be typing into a text field, using type-ahead search
  * in a `select` element, etc.
  */
 export const isFocusingTextControl = (target: EventTarget): boolean => {

--- a/ecosystem/plugin-search/src/client/utils/isFocusingTextControl.ts
+++ b/ecosystem/plugin-search/src/client/utils/isFocusingTextControl.ts
@@ -8,7 +8,7 @@ export function isFocusingTextControl(target: EventTarget): boolean {
       (['TEXTAREA', 'SELECT', 'INPUT'].includes(target.tagName) ||
         target.hasAttribute('contenteditable'))
     )
-  } else {
-    return false
   }
+
+  return false
 }

--- a/ecosystem/plugin-search/src/client/utils/isFocusingTextControl.ts
+++ b/ecosystem/plugin-search/src/client/utils/isFocusingTextControl.ts
@@ -1,0 +1,14 @@
+/**
+ * Determines whether the user is currently focusing a text control. In this case, the search plugin shouldn’t hijack any hotkeys because the user might be typing into a text field, using type-ahead search in a `select` element, etc.
+ */
+export function isFocusingTextControl(target: EventTarget): boolean {
+  if (target instanceof HTMLElement) {
+    return (
+      document.activeElement === target &&
+      (['TEXTAREA', 'SELECT', 'INPUT'].includes(target.tagName) ||
+        target.hasAttribute('contenteditable'))
+    )
+  } else {
+    return false
+  }
+}

--- a/ecosystem/plugin-search/src/client/utils/isFocusingTextControl.ts
+++ b/ecosystem/plugin-search/src/client/utils/isFocusingTextControl.ts
@@ -2,7 +2,7 @@
  * Determines whether the user is currently focusing a text control. In this case, the search plugin shouldn’t hijack any hotkeys because the user might be typing into a text field, using type-ahead search in a `select` element, etc.
  */
 export function isFocusingTextControl(target: EventTarget): boolean {
-  if (target instanceof HTMLElement) {
+  if (target instanceof Element) {
     return (
       document.activeElement === target &&
       (['TEXTAREA', 'SELECT', 'INPUT'].includes(target.tagName) ||

--- a/ecosystem/plugin-search/src/client/utils/isFocusingTextControl.ts
+++ b/ecosystem/plugin-search/src/client/utils/isFocusingTextControl.ts
@@ -1,14 +1,16 @@
 /**
- * Determines whether the user is currently focusing a text control. In this case, the search plugin shouldn’t hijack any hotkeys because the user might be typing into a text field, using type-ahead search in a `select` element, etc.
+ * Determines whether the user is currently focusing a text control.
+ * In this case, the search plugin shouldn’t hijack any hotkeys because
+ * the user might be typing into a text field, using type-ahead search 
+ * in a `select` element, etc.
  */
-export function isFocusingTextControl(target: EventTarget): boolean {
-  if (target instanceof Element) {
-    return (
-      document.activeElement === target &&
-      (['TEXTAREA', 'SELECT', 'INPUT'].includes(target.tagName) ||
-        target.hasAttribute('contenteditable'))
-    )
+export const isFocusingTextControl = (target: EventTarget): boolean => {
+  if (!(target instanceof Element)) {
+    return false
   }
-
-  return false
+  return (
+    document.activeElement === target &&
+    (['TEXTAREA', 'SELECT', 'INPUT'].includes(target.tagName) ||
+      target.hasAttribute('contenteditable'))
+  )
 }


### PR DESCRIPTION
## Changes

Fixes an issue with the search plugin’s hotkey being triggered while typing into a text control (e.g. when setting the shortcut to <kbd>/</kbd> and then trying to type `/` into an `input[type=text]`).

## Notes

This added logic is probably not entirely complete and accurate. It would probably be more accurate to only check `input` elements of certain types for example, but I think this should not cause issues.