### PR TITLE
feat(markdown): make ext as attr instead of class

### DIFF
--- a/ecosystem/theme-default/src/client/styles/_variables.scss
+++ b/ecosystem/theme-default/src/client/styles/_variables.scss
@@ -4,8 +4,3 @@
 $MQNarrow: 959px !default;
 $MQMobile: 719px !default;
 $MQMobileNarrow: 419px !default;
-
-// code languages
-$codeLang: 'c' 'cpp' 'cs' 'css' 'dart' 'docker' 'fs' 'go' 'html' 'java' 'js'
-  'json' 'kt' 'less' 'makefile' 'md' 'php' 'py' 'rb' 'rs' 'sass' 'scss' 'sh'
-  'styl' 'ts' 'toml' 'vue' 'yml' !default;

--- a/ecosystem/theme-default/src/client/styles/code.scss
+++ b/ecosystem/theme-default/src/client/styles/code.scss
@@ -152,6 +152,7 @@ div[class*='language-'] {
   border-radius: 6px;
 
   &::before {
+    content: attr(data-ext);
     position: absolute;
     z-index: 3;
     top: 0.8em;
@@ -243,14 +244,6 @@ div[class*='language-'] {
       height: 100%;
       border-radius: 6px 0 0 6px;
       border-right: 1px solid var(--code-hl-bg-color);
-    }
-  }
-}
-
-@each $lang in $codeLang {
-  div[class*='language-'].ext-#{$lang} {
-    &:before {
-      content: '' + $lang;
     }
   }
 }

--- a/packages/markdown/src/plugins/codePlugin/codePlugin.ts
+++ b/packages/markdown/src/plugins/codePlugin/codePlugin.ts
@@ -128,9 +128,9 @@ export const codePlugin: PluginWithOptions<CodePluginOptions> = (
       result = `${result}<div class="line-numbers" aria-hidden="true">${lineNumbersCode}</div>`
     }
 
-    result = `<div class="${languageClass} ext-${language.ext}${
+    result = `<div class="${languageClass}${
       useLineNumbers ? ' line-numbers-mode' : ''
-    }">${result}</div>`
+    }" data-ext="${language.ext}">${result}</div>`
 
     return result
   }

--- a/packages/markdown/tests/plugins/__snapshots__/codePlugin.spec.ts.snap
+++ b/packages/markdown/tests/plugins/__snapshots__/codePlugin.spec.ts.snap
@@ -1,35 +1,35 @@
 // Vitest Snapshot v1
 
 exports[`@vuepress/markdown > plugins > codePlugin > :line-numbers / :no-line-numbers > should work properly if \`lineNumbers\` is disabled by default 1`] = `
-"<div class=\\"language-text ext-text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre></div><div class=\\"language-text ext-text line-numbers-mode\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text ext-text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre></div><div class=\\"language-typescript ext-ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+"<div class=\\"language-text\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre></div><div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre></div><div class=\\"language-typescript\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre></div><div class=\\"language-typescript ext-ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre></div><div class=\\"language-typescript\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
@@ -38,35 +38,35 @@ function bar () {
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin > :line-numbers / :no-line-numbers > should work properly if \`lineNumbers\` is enabled by default 1`] = `
-"<div class=\\"language-text ext-text line-numbers-mode\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text ext-text line-numbers-mode\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text ext-text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+"<div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
@@ -75,35 +75,35 @@ function bar () {
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin > :line-numbers / :no-line-numbers > should work properly if \`lineNumbers\` is set to a number by default 1`] = `
-"<div class=\\"language-text ext-text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre></div><div class=\\"language-text ext-text line-numbers-mode\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text ext-text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+"<div class=\\"language-text\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre></div><div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
@@ -112,35 +112,35 @@ function bar () {
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin > :v-pre / :no-v-pre > should work properly if \`vPre.block\` is disabled by default 1`] = `
-"<div class=\\"language-text ext-text line-numbers-mode\\"><pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text ext-text line-numbers-mode\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text ext-text line-numbers-mode\\"><pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
+"<div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
@@ -149,35 +149,35 @@ function bar () {
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin > :v-pre / :no-v-pre > should work properly if \`vPre.block\` is enabled by default 1`] = `
-"<div class=\\"language-text ext-text line-numbers-mode\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text ext-text line-numbers-mode\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text ext-text line-numbers-mode\\"><pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+"<div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
@@ -186,18 +186,18 @@ function bar () {
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin > plugin options > should disable \`highlightLines\` 1`] = `
-"<div class=\\"language-text ext-text line-numbers-mode\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+"<div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
@@ -211,18 +211,18 @@ const baz = () =&gt; {
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin > plugin options > should disable \`lineNumbers\` 1`] = `
-"<div class=\\"language-text ext-text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre></div><div class=\\"language-typescript ext-ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+"<div class=\\"language-text\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre></div><div class=\\"language-typescript\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre></div><div class=\\"language-typescript ext-ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre></div><div class=\\"language-typescript\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div></div><div class=\\"language-typescript ext-ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div></div><div class=\\"language-typescript\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
@@ -261,18 +261,18 @@ const baz = () =&gt; {
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin > plugin options > should disable \`vPre.block\` 1`] = `
-"<div class=\\"language-text ext-text line-numbers-mode\\"><pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
+"<div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
@@ -286,18 +286,18 @@ const baz = () =&gt; {
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin > plugin options > should disable \`vPre.inline\` 1`] = `
-"<div class=\\"language-text ext-text line-numbers-mode\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+"<div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
@@ -311,18 +311,18 @@ const baz = () =&gt; {
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin > plugin options > should disable \`vPre.inline\` and \`vPre.block\` 1`] = `
-"<div class=\\"language-text ext-text line-numbers-mode\\"><pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
+"<div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
@@ -336,18 +336,18 @@ const baz = () =&gt; {
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin > plugin options > should enable \`lineNumbers\` according to number of code lines 1`] = `
-"<div class=\\"language-text ext-text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+"<div class=\\"language-text\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
@@ -361,18 +361,18 @@ const baz = () =&gt; {
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin > plugin options > should process code fences with default options 1`] = `
-"<div class=\\"language-text ext-text line-numbers-mode\\"><pre v-pre class=\\"language-text\\"><code>Raw text
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+"<div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>Raw text
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
 }
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br><br><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>const foo = 'foo'
 
 function bar () {
   return 1024
@@ -386,18 +386,18 @@ const baz = () =&gt; {
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin > syntax highlighting > should work if highlighted code is not wrapped with \`<pre>\` 1`] = `
-"<div class=\\"language-text ext-text line-numbers-mode\\"><pre v-pre class=\\"language-text\\"><code>highlighted code: Raw text
-, lang: text</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-javascript ext-js line-numbers-mode\\"><pre v-pre class=\\"language-javascript\\"><code>highlighted code: const foo = 'foo'
+"<div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre v-pre class=\\"language-text\\"><code>highlighted code: Raw text
+, lang: text</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-javascript line-numbers-mode\\" data-ext=\\"js\\"><pre v-pre class=\\"language-javascript\\"><code>highlighted code: const foo = 'foo'
 
 function bar () {
   return 1024
 }
-, lang: javascript</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre class=\\"language-typescript\\"><code>highlighted code: const foo: string = 'foo'
+, lang: javascript</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre class=\\"language-typescript\\"><code>highlighted code: const foo: string = 'foo'
 
 function bar (): number {
   return 1024
 }
-, lang: typescript</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-vue-html ext-vue-html line-numbers-mode\\"><pre v-pre class=\\"language-vue-html\\"><code>highlighted code: <template>
+, lang: typescript</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-vue-html line-numbers-mode\\" data-ext=\\"vue-html\\"><pre v-pre class=\\"language-vue-html\\"><code>highlighted code: <template>
   <div>msg: {{msg}}</div>
 </template>
 <script setup lang=\\"ts\\">
@@ -407,18 +407,18 @@ const msg = 'hello world';
 `;
 
 exports[`@vuepress/markdown > plugins > codePlugin > syntax highlighting > should work if highlighted code is wrapped with \`<pre>\` 1`] = `
-"<div class=\\"language-text ext-text line-numbers-mode\\"><pre v-pre><code>highlighted code: Raw text
-, lang: text</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-javascript ext-js line-numbers-mode\\"><pre v-pre><code>highlighted code: const foo = 'foo'
+"<div class=\\"language-text line-numbers-mode\\" data-ext=\\"text\\"><pre v-pre><code>highlighted code: Raw text
+, lang: text</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div></div></div><div class=\\"language-javascript line-numbers-mode\\" data-ext=\\"js\\"><pre v-pre><code>highlighted code: const foo = 'foo'
 
 function bar () {
   return 1024
 }
-, lang: javascript</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript ext-ts line-numbers-mode\\"><pre v-pre><code>highlighted code: const foo: string = 'foo'
+, lang: javascript</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-typescript line-numbers-mode\\" data-ext=\\"ts\\"><pre v-pre><code>highlighted code: const foo: string = 'foo'
 
 function bar (): number {
   return 1024
 }
-, lang: typescript</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-vue-html ext-vue-html line-numbers-mode\\"><pre v-pre><code>highlighted code: <template>
+, lang: typescript</code></pre><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-vue-html line-numbers-mode\\" data-ext=\\"vue-html\\"><pre v-pre><code>highlighted code: <template>
   <div>msg: {{msg}}</div>
 </template>
 <script setup lang=\\"ts\\">

--- a/packages/markdown/tests/plugins/__snapshots__/importCodePlugin.spec.ts.snap
+++ b/packages/markdown/tests/plugins/__snapshots__/importCodePlugin.spec.ts.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1
 
 exports[`@vuepress/markdown > plugins > importCodePlugin > compatibility with codePlugin > should work with syntax supported by codePlugin 1`] = `
-"<div class=\\"language-javascript ext-js line-numbers-mode\\"><pre v-pre class=\\"language-javascript\\"><code>const msg = 'hello from js'
+"<div class=\\"language-javascript line-numbers-mode\\" data-ext=\\"js\\"><pre v-pre class=\\"language-javascript\\"><code>const msg = 'hello from js'
 
 console.log(msg)
 
 console.log('foo bar')
-</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><br><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-markdown ext-md\\"><pre v-pre class=\\"language-markdown\\"><code># msg
+</code></pre><div class=\\"highlight-lines\\"><div class=\\"highlight-line\\">&nbsp;</div><br><div class=\\"highlight-line\\">&nbsp;</div><div class=\\"highlight-line\\">&nbsp;</div><br></div><div class=\\"line-numbers\\" aria-hidden=\\"true\\"><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div><div class=\\"line-number\\"></div></div></div><div class=\\"language-markdown\\" data-ext=\\"md\\"><pre v-pre class=\\"language-markdown\\"><code># msg
 
 hello from md
 


### PR DESCRIPTION
This change make it possible to support ext marker automatically:
