### PR TITLE
feat(default-theme): Hero image link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 home: true
 title: Home
 heroImage: /images/hero.png
+heroImageLink: 'https://v2.vuepress.vuejs.org'
 actions:
   - text: Get Started
     link: /guide/getting-started.html

--- a/docs/reference/default-theme/frontmatter.md
+++ b/docs/reference/default-theme/frontmatter.md
@@ -115,6 +115,22 @@ heroImage: https://vuejs.org/images/logo.png
   - [Default Theme > Frontmatter > heroImage](#heroimage)
   - [Default Theme > Config > colorMode](./config.md#colormode)
 
+### heroImageLink
+
+- Type: `string`
+
+- Details:
+
+  Specify where the hero image should link to.
+
+- Example:
+
+```md
+---
+heroImageLink: https://v2.vuepress.vuejs.org
+---
+```
+
 ### heroAlt
 
 - Type: `string`

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -2,6 +2,7 @@
 home: true
 title: 首页
 heroImage: /images/hero.png
+heroImageLink: 'https://v2.vuepress.vuejs.org'
 actions:
   - text: 快速上手
     link: /zh/guide/getting-started.html

--- a/ecosystem/theme-default/src/client/components/HomeHero.vue
+++ b/ecosystem/theme-default/src/client/components/HomeHero.vue
@@ -59,11 +59,14 @@ const actions = computed(() => {
 
 const HomeHeroImage: FunctionalComponent = () => {
   if (!heroImage.value) return null
-  const img = h('img', {
+  let img = h('img', {
     src: withBase(heroImage.value),
     alt: heroAlt.value,
     height: heroHeight.value,
   })
+  if (frontmatter.value.heroImageLink !== undefined) {
+    img = h('a', { href: frontmatter.value.heroImageLink }, [img])
+  }
   if (frontmatter.value.heroImageDark === undefined) {
     return img
   }


### PR DESCRIPTION
This adds the option `heroImageLink` to the frontmatter which will wrap the hero image in an `<a>` anchor that links to the given URL.

The second commit (d04a0d9fadc1fdf21606a4718e1984b958c4860c) applies this to the docs site, but it can be omitted as it does not add value to the docs site itself.

**Help needed:** Chinese translation of the reference