### PR TITLE
feat(utils): migrate to picocolors

### DIFF
--- a/ecosystem/plugin-container/src/node/containerPlugin.ts
+++ b/ecosystem/plugin-container/src/node/containerPlugin.ts
@@ -2,7 +2,7 @@ import type { Plugin, PluginObject } from '@vuepress/core'
 import type { MarkdownEnv } from '@vuepress/markdown'
 import type { LocaleConfig } from '@vuepress/shared'
 import { ensureLeadingSlash, resolveLocalePath } from '@vuepress/shared'
-import { chalk, logger } from '@vuepress/utils'
+import { logger, picocolors } from '@vuepress/utils'
 import container from 'markdown-it-container'
 import type Renderer from 'markdown-it/lib/renderer.js'
 import type Token from 'markdown-it/lib/token.js'
@@ -102,7 +102,9 @@ export const containerPlugin = ({
 
   // `type` option is required
   if (!type) {
-    logger.warn(`[${plugin.name}] ${chalk.magenta('type')} option is required`)
+    logger.warn(
+      `[${plugin.name}] ${picocolors.magenta('type')} option is required`
+    )
     return plugin
   }
 

--- a/ecosystem/plugin-container/src/node/containerPlugin.ts
+++ b/ecosystem/plugin-container/src/node/containerPlugin.ts
@@ -2,7 +2,7 @@ import type { Plugin, PluginObject } from '@vuepress/core'
 import type { MarkdownEnv } from '@vuepress/markdown'
 import type { LocaleConfig } from '@vuepress/shared'
 import { ensureLeadingSlash, resolveLocalePath } from '@vuepress/shared'
-import { logger, picocolors } from '@vuepress/utils'
+import { colors, logger } from '@vuepress/utils'
 import container from 'markdown-it-container'
 import type Renderer from 'markdown-it/lib/renderer.js'
 import type Token from 'markdown-it/lib/token.js'
@@ -102,9 +102,7 @@ export const containerPlugin = ({
 
   // `type` option is required
   if (!type) {
-    logger.warn(
-      `[${plugin.name}] ${picocolors.magenta('type')} option is required`
-    )
+    logger.warn(`[${plugin.name}] ${colors.magenta('type')} option is required`)
     return plugin
   }
 

--- a/packages/bundler-vite/src/build/build.ts
+++ b/packages/bundler-vite/src/build/build.ts
@@ -1,6 +1,6 @@
 import type { CreateVueAppFunction } from '@vuepress/client'
 import type { App, Bundler } from '@vuepress/core'
-import { debug, fs, importFile, picocolors, withSpinner } from '@vuepress/utils'
+import { colors, debug, fs, importFile, withSpinner } from '@vuepress/utils'
 import type { OutputAsset, OutputChunk, RollupOutput } from 'rollup'
 import { build as viteBuild } from 'vite'
 import { resolveViteConfig } from '../resolveViteConfig.js'
@@ -74,8 +74,7 @@ export const build = async (
 
     // pre-render pages to html files
     for (const page of app.pages) {
-      if (spinner)
-        spinner.text = `Rendering pages ${picocolors.magenta(page.path)}`
+      if (spinner) spinner.text = `Rendering pages ${colors.magenta(page.path)}`
       await renderPage({
         app,
         page,

--- a/packages/bundler-vite/src/build/build.ts
+++ b/packages/bundler-vite/src/build/build.ts
@@ -1,6 +1,6 @@
 import type { CreateVueAppFunction } from '@vuepress/client'
 import type { App, Bundler } from '@vuepress/core'
-import { chalk, debug, fs, importFile, withSpinner } from '@vuepress/utils'
+import { debug, fs, importFile, picocolors, withSpinner } from '@vuepress/utils'
 import type { OutputAsset, OutputChunk, RollupOutput } from 'rollup'
 import { build as viteBuild } from 'vite'
 import { resolveViteConfig } from '../resolveViteConfig.js'
@@ -74,7 +74,8 @@ export const build = async (
 
     // pre-render pages to html files
     for (const page of app.pages) {
-      if (spinner) spinner.text = `Rendering pages ${chalk.magenta(page.path)}`
+      if (spinner)
+        spinner.text = `Rendering pages ${picocolors.magenta(page.path)}`
       await renderPage({
         app,
         page,

--- a/packages/bundler-vite/src/dev.ts
+++ b/packages/bundler-vite/src/dev.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module'
 import type { App, Bundler } from '@vuepress/core'
-import { chalk, fs } from '@vuepress/utils'
+import { fs, picocolors } from '@vuepress/utils'
 import { createServer } from 'vite'
 import { resolveViteConfig } from './resolveViteConfig.js'
 import type { ViteBundlerOptions } from './types.js'
@@ -28,8 +28,8 @@ export const dev = async (
     require.resolve('vite/package.json')
   ).version
   server.config.logger.info(
-    chalk.cyan(`\n  vite v${viteVersion}`) +
-      chalk.green(` dev server running at:\n`),
+    picocolors.cyan(`\n  vite v${viteVersion}`) +
+      picocolors.green(` dev server running at:\n`),
     {
       clear: !server.config.logger.hasWarned,
     }

--- a/packages/bundler-vite/src/dev.ts
+++ b/packages/bundler-vite/src/dev.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module'
 import type { App, Bundler } from '@vuepress/core'
-import { fs, picocolors } from '@vuepress/utils'
+import { colors, fs } from '@vuepress/utils'
 import { createServer } from 'vite'
 import { resolveViteConfig } from './resolveViteConfig.js'
 import type { ViteBundlerOptions } from './types.js'
@@ -28,8 +28,8 @@ export const dev = async (
     require.resolve('vite/package.json')
   ).version
   server.config.logger.info(
-    picocolors.cyan(`\n  vite v${viteVersion}`) +
-      picocolors.green(` dev server running at:\n`),
+    colors.cyan(`\n  vite v${viteVersion}`) +
+      colors.green(` dev server running at:\n`),
     {
       clear: !server.config.logger.hasWarned,
     }

--- a/packages/bundler-webpack/src/build/build.ts
+++ b/packages/bundler-webpack/src/build/build.ts
@@ -1,10 +1,10 @@
 import type { CreateVueAppFunction } from '@vuepress/client'
 import type { App, Bundler } from '@vuepress/core'
 import {
-  chalk,
   debug,
   fs,
   importFileDefault,
+  picocolors,
   withSpinner,
 } from '@vuepress/utils'
 import webpack from 'webpack'
@@ -98,7 +98,7 @@ export const build = async (
     // pre-render pages to html files
     for (const page of app.pages) {
       if (spinner) {
-        spinner.text = `Rendering pages ${chalk.magenta(page.path)}`
+        spinner.text = `Rendering pages ${picocolors.magenta(page.path)}`
       }
       await renderPage({
         app,

--- a/packages/bundler-webpack/src/build/build.ts
+++ b/packages/bundler-webpack/src/build/build.ts
@@ -1,10 +1,10 @@
 import type { CreateVueAppFunction } from '@vuepress/client'
 import type { App, Bundler } from '@vuepress/core'
 import {
+  colors,
   debug,
   fs,
   importFileDefault,
-  picocolors,
   withSpinner,
 } from '@vuepress/utils'
 import webpack from 'webpack'
@@ -98,7 +98,7 @@ export const build = async (
     // pre-render pages to html files
     for (const page of app.pages) {
       if (spinner) {
-        spinner.text = `Rendering pages ${picocolors.magenta(page.path)}`
+        spinner.text = `Rendering pages ${colors.magenta(page.path)}`
       }
       await renderPage({
         app,

--- a/packages/bundler-webpack/src/dev/dev.ts
+++ b/packages/bundler-webpack/src/dev/dev.ts
@@ -1,5 +1,5 @@
 import type { App, Bundler } from '@vuepress/core'
-import { logger, ora, picocolors } from '@vuepress/utils'
+import { colors, logger, ora } from '@vuepress/utils'
 import webpack from 'webpack'
 import WebpackDevServer from 'webpack-dev-server'
 import { resolveWebpackConfig } from '../resolveWebpackConfig.js'
@@ -63,7 +63,7 @@ export const dev = async (
           serverConfig.host === '0.0.0.0' ? 'localhost' : serverConfig.host
         }:${serverConfig.port}${app.options.base}`
         logger.success(
-          `VuePress webpack dev server is listening at ${picocolors.cyan(url)}`
+          `VuePress webpack dev server is listening at ${colors.cyan(url)}`
         )
 
         // resolve the close function

--- a/packages/bundler-webpack/src/dev/dev.ts
+++ b/packages/bundler-webpack/src/dev/dev.ts
@@ -1,5 +1,5 @@
 import type { App, Bundler } from '@vuepress/core'
-import { chalk, logger, ora } from '@vuepress/utils'
+import { logger, ora, picocolors } from '@vuepress/utils'
 import webpack from 'webpack'
 import WebpackDevServer from 'webpack-dev-server'
 import { resolveWebpackConfig } from '../resolveWebpackConfig.js'
@@ -63,7 +63,7 @@ export const dev = async (
           serverConfig.host === '0.0.0.0' ? 'localhost' : serverConfig.host
         }:${serverConfig.port}${app.options.base}`
         logger.success(
-          `VuePress webpack dev server is listening at ${chalk.cyan(url)}`
+          `VuePress webpack dev server is listening at ${picocolors.cyan(url)}`
         )
 
         // resolve the close function

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module'
 import process from 'node:process'
 import type { AppConfig } from '@vuepress/core'
-import { chalk } from '@vuepress/utils'
+import { picocolors } from '@vuepress/utils'
 import { cac } from 'cac'
 import { createBuild, createDev, info } from './commands/index.js'
 
@@ -60,7 +60,7 @@ export const cli = (defaultAppConfig: Partial<AppConfig> = {}): void => {
   // run command or fallback to help messages
   if (program.matchedCommand) {
     program.runMatchedCommand().catch((err) => {
-      console.error(chalk.red(err.stack))
+      console.error(picocolors.red(err.stack))
       process.exit(1)
     })
   } else {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module'
 import process from 'node:process'
 import type { AppConfig } from '@vuepress/core'
-import { picocolors } from '@vuepress/utils'
+import { colors } from '@vuepress/utils'
 import { cac } from 'cac'
 import { createBuild, createDev, info } from './commands/index.js'
 
@@ -60,7 +60,7 @@ export const cli = (defaultAppConfig: Partial<AppConfig> = {}): void => {
   // run command or fallback to help messages
   if (program.matchedCommand) {
     program.runMatchedCommand().catch((err) => {
-      console.error(picocolors.red(err.stack))
+      console.error(colors.red(err.stack))
       process.exit(1)
     })
   } else {

--- a/packages/cli/src/commands/dev/watchPageFiles.ts
+++ b/packages/cli/src/commands/dev/watchPageFiles.ts
@@ -1,5 +1,5 @@
 import type { App, Page } from '@vuepress/core'
-import { chalk, logger } from '@vuepress/utils'
+import { logger, picocolors } from '@vuepress/utils'
 import chokidar from 'chokidar'
 import type { FSWatcher } from 'chokidar'
 import { handlePageAdd } from './handlePageAdd.js'
@@ -30,7 +30,7 @@ export const watchPageFiles = (app: App): FSWatcher[] => {
     if (!pagePaths) return
     for (const filePathRelative of pagePaths) {
       logger.info(
-        `dependency of page ${chalk.magenta(filePathRelative)} is modified`
+        `dependency of page ${picocolors.magenta(filePathRelative)} is modified`
       )
       await handlePageChange(app, app.dir.source(filePathRelative))
     }
@@ -46,13 +46,13 @@ export const watchPageFiles = (app: App): FSWatcher[] => {
     ignoreInitial: true,
   })
   pagesWatcher.on('add', async (filePathRelative) => {
-    logger.info(`page ${chalk.magenta(filePathRelative)} is created`)
+    logger.info(`page ${picocolors.magenta(filePathRelative)} is created`)
     const page = await handlePageAdd(app, app.dir.source(filePathRelative))
     if (page === null) return
     addDeps(page)
   })
   pagesWatcher.on('change', async (filePathRelative) => {
-    logger.info(`page ${chalk.magenta(filePathRelative)} is modified`)
+    logger.info(`page ${picocolors.magenta(filePathRelative)} is modified`)
     const result = await handlePageChange(app, app.dir.source(filePathRelative))
     if (result === null) return
     const [pageOld, pageNew] = result
@@ -60,7 +60,7 @@ export const watchPageFiles = (app: App): FSWatcher[] => {
     addDeps(pageNew)
   })
   pagesWatcher.on('unlink', async (filePathRelative) => {
-    logger.info(`page ${chalk.magenta(filePathRelative)} is removed`)
+    logger.info(`page ${picocolors.magenta(filePathRelative)} is removed`)
     const page = await handlePageUnlink(app, app.dir.source(filePathRelative))
     if (page === null) return
     removeDeps(page)

--- a/packages/cli/src/commands/dev/watchPageFiles.ts
+++ b/packages/cli/src/commands/dev/watchPageFiles.ts
@@ -1,5 +1,5 @@
 import type { App, Page } from '@vuepress/core'
-import { logger, picocolors } from '@vuepress/utils'
+import { colors, logger } from '@vuepress/utils'
 import chokidar from 'chokidar'
 import type { FSWatcher } from 'chokidar'
 import { handlePageAdd } from './handlePageAdd.js'
@@ -30,7 +30,7 @@ export const watchPageFiles = (app: App): FSWatcher[] => {
     if (!pagePaths) return
     for (const filePathRelative of pagePaths) {
       logger.info(
-        `dependency of page ${picocolors.magenta(filePathRelative)} is modified`
+        `dependency of page ${colors.magenta(filePathRelative)} is modified`
       )
       await handlePageChange(app, app.dir.source(filePathRelative))
     }
@@ -46,13 +46,13 @@ export const watchPageFiles = (app: App): FSWatcher[] => {
     ignoreInitial: true,
   })
   pagesWatcher.on('add', async (filePathRelative) => {
-    logger.info(`page ${picocolors.magenta(filePathRelative)} is created`)
+    logger.info(`page ${colors.magenta(filePathRelative)} is created`)
     const page = await handlePageAdd(app, app.dir.source(filePathRelative))
     if (page === null) return
     addDeps(page)
   })
   pagesWatcher.on('change', async (filePathRelative) => {
-    logger.info(`page ${picocolors.magenta(filePathRelative)} is modified`)
+    logger.info(`page ${colors.magenta(filePathRelative)} is modified`)
     const result = await handlePageChange(app, app.dir.source(filePathRelative))
     if (result === null) return
     const [pageOld, pageNew] = result
@@ -60,7 +60,7 @@ export const watchPageFiles = (app: App): FSWatcher[] => {
     addDeps(pageNew)
   })
   pagesWatcher.on('unlink', async (filePathRelative) => {
-    logger.info(`page ${picocolors.magenta(filePathRelative)} is removed`)
+    logger.info(`page ${colors.magenta(filePathRelative)} is removed`)
     const page = await handlePageUnlink(app, app.dir.source(filePathRelative))
     if (page === null) return
     removeDeps(page)

--- a/packages/cli/src/commands/dev/watchUserConfigFile.ts
+++ b/packages/cli/src/commands/dev/watchUserConfigFile.ts
@@ -1,5 +1,5 @@
 import process from 'node:process'
-import { logger, picocolors } from '@vuepress/utils'
+import { colors, logger } from '@vuepress/utils'
 import chokidar from 'chokidar'
 import type { FSWatcher } from 'chokidar'
 
@@ -19,7 +19,7 @@ export const watchUserConfigFile = ({
     ignoreInitial: true,
   })
   configWatcher.on('change', (configFile) => {
-    logger.info(`config ${picocolors.magenta(configFile)} is modified`)
+    logger.info(`config ${colors.magenta(configFile)} is modified`)
     restart()
   })
 
@@ -28,7 +28,7 @@ export const watchUserConfigFile = ({
     ignoreInitial: true,
   })
   depsWatcher.on('change', (depFile) => {
-    logger.info(`config dependency ${picocolors.magenta(depFile)} is modified`)
+    logger.info(`config dependency ${colors.magenta(depFile)} is modified`)
     restart()
   })
 

--- a/packages/cli/src/commands/dev/watchUserConfigFile.ts
+++ b/packages/cli/src/commands/dev/watchUserConfigFile.ts
@@ -1,5 +1,5 @@
 import process from 'node:process'
-import { chalk, logger } from '@vuepress/utils'
+import { logger, picocolors } from '@vuepress/utils'
 import chokidar from 'chokidar'
 import type { FSWatcher } from 'chokidar'
 
@@ -19,7 +19,7 @@ export const watchUserConfigFile = ({
     ignoreInitial: true,
   })
   configWatcher.on('change', (configFile) => {
-    logger.info(`config ${chalk.magenta(configFile)} is modified`)
+    logger.info(`config ${picocolors.magenta(configFile)} is modified`)
     restart()
   })
 
@@ -28,7 +28,7 @@ export const watchUserConfigFile = ({
     ignoreInitial: true,
   })
   depsWatcher.on('change', (depFile) => {
-    logger.info(`config dependency ${chalk.magenta(depFile)} is modified`)
+    logger.info(`config dependency ${picocolors.magenta(depFile)} is modified`)
     restart()
   })
 

--- a/packages/cli/src/config/resolveAppConfig.ts
+++ b/packages/cli/src/config/resolveAppConfig.ts
@@ -1,6 +1,6 @@
 import type { AppConfig } from '@vuepress/core'
 import { ensureEndingSlash, ensureLeadingSlash } from '@vuepress/shared'
-import { isChildPath, logger, picocolors } from '@vuepress/utils'
+import { colors, isChildPath, logger } from '@vuepress/utils'
 
 /**
  * Resolve app config according to:
@@ -29,9 +29,7 @@ export const resolveAppConfig = ({
 
   if (appConfig.bundler === undefined || appConfig.theme === undefined) {
     logger.error(
-      `${picocolors.magenta('bundler')} and ${picocolors.magenta(
-        'theme'
-      )} are required`
+      `${colors.magenta('bundler')} and ${colors.magenta('theme')} are required`
     )
     return null
   }
@@ -45,15 +43,15 @@ export const resolveAppConfig = ({
       | '/'
       | `/${string}/`
     logger.warn(
-      `${picocolors.magenta('base')} should start and end with a slash (/),` +
-        ` so it has been normalized from ${picocolors.magenta(rawBase)}` +
-        ` to ${picocolors.magenta(appConfig.base)}`
+      `${colors.magenta('base')} should start and end with a slash (/),` +
+        ` so it has been normalized from ${colors.magenta(rawBase)}` +
+        ` to ${colors.magenta(appConfig.base)}`
     )
   }
 
   if (appConfig.dest && isChildPath(appConfig.source, appConfig.dest)) {
     logger.warn(
-      `${picocolors.magenta('dest')} directory would be emptied during build,` +
+      `${colors.magenta('dest')} directory would be emptied during build,` +
         ` so we fallback it to the default directory for the safety of your source files`
     )
     delete appConfig.dest

--- a/packages/cli/src/config/resolveAppConfig.ts
+++ b/packages/cli/src/config/resolveAppConfig.ts
@@ -1,6 +1,6 @@
 import type { AppConfig } from '@vuepress/core'
 import { ensureEndingSlash, ensureLeadingSlash } from '@vuepress/shared'
-import { chalk, isChildPath, logger } from '@vuepress/utils'
+import { isChildPath, logger, picocolors } from '@vuepress/utils'
 
 /**
  * Resolve app config according to:
@@ -29,7 +29,9 @@ export const resolveAppConfig = ({
 
   if (appConfig.bundler === undefined || appConfig.theme === undefined) {
     logger.error(
-      `${chalk.magenta('bundler')} and ${chalk.magenta('theme')} are required`
+      `${picocolors.magenta('bundler')} and ${picocolors.magenta(
+        'theme'
+      )} are required`
     )
     return null
   }
@@ -43,15 +45,15 @@ export const resolveAppConfig = ({
       | '/'
       | `/${string}/`
     logger.warn(
-      `${chalk.magenta('base')} should start and end with a slash (/),` +
-        ` so it has been normalized from ${chalk.magenta(rawBase)}` +
-        ` to ${chalk.magenta(appConfig.base)}`
+      `${picocolors.magenta('base')} should start and end with a slash (/),` +
+        ` so it has been normalized from ${picocolors.magenta(rawBase)}` +
+        ` to ${picocolors.magenta(appConfig.base)}`
     )
   }
 
   if (appConfig.dest && isChildPath(appConfig.source, appConfig.dest)) {
     logger.warn(
-      `${chalk.magenta('dest')} directory would be emptied during build,` +
+      `${picocolors.magenta('dest')} directory would be emptied during build,` +
         ` so we fallback it to the default directory for the safety of your source files`
     )
     delete appConfig.dest

--- a/packages/cli/src/config/resolveUserConfigPath.ts
+++ b/packages/cli/src/config/resolveUserConfigPath.ts
@@ -1,5 +1,5 @@
 import process from 'node:process'
-import { fs, logger, path, picocolors } from '@vuepress/utils'
+import { colors, fs, logger, path } from '@vuepress/utils'
 
 /**
  * Resolve file path of user config
@@ -12,7 +12,7 @@ export const resolveUserConfigPath = (
 
   if (!fs.pathExistsSync(configPath)) {
     throw logger.createError(
-      `config file does not exist: ${picocolors.magenta(config)}`
+      `config file does not exist: ${colors.magenta(config)}`
     )
   }
 

--- a/packages/cli/src/config/resolveUserConfigPath.ts
+++ b/packages/cli/src/config/resolveUserConfigPath.ts
@@ -1,5 +1,5 @@
 import process from 'node:process'
-import { chalk, fs, logger, path } from '@vuepress/utils'
+import { fs, logger, path, picocolors } from '@vuepress/utils'
 
 /**
  * Resolve file path of user config
@@ -12,7 +12,7 @@ export const resolveUserConfigPath = (
 
   if (!fs.pathExistsSync(configPath)) {
     throw logger.createError(
-      `config file does not exist: ${chalk.magenta(config)}`
+      `config file does not exist: ${picocolors.magenta(config)}`
     )
   }
 

--- a/packages/core/src/app/appUse.ts
+++ b/packages/core/src/app/appUse.ts
@@ -1,4 +1,4 @@
-import { debug, picocolors, warn } from '@vuepress/utils'
+import { colors, debug, warn } from '@vuepress/utils'
 import type { App, Plugin } from '../types/index.js'
 import { resolvePluginObject } from './resolvePluginObject.js'
 
@@ -13,7 +13,7 @@ export const appUse = (app: App, rawPlugin: Plugin): App => {
     return app
   }
 
-  log(`use plugin ${picocolors.magenta(pluginObject.name)}`)
+  log(`use plugin ${colors.magenta(pluginObject.name)}`)
 
   // handle duplicated plugins
   if (pluginObject.multiple !== true) {
@@ -24,7 +24,7 @@ export const appUse = (app: App, rawPlugin: Plugin): App => {
       // remove the previous duplicated plugin
       app.pluginApi.plugins.splice(duplicateIndex, 1)
       warn(
-        `plugin ${picocolors.magenta(
+        `plugin ${colors.magenta(
           pluginObject.name
         )} has been used multiple times, only the last one will take effect`
       )

--- a/packages/core/src/app/appUse.ts
+++ b/packages/core/src/app/appUse.ts
@@ -1,4 +1,4 @@
-import { chalk, debug, warn } from '@vuepress/utils'
+import { debug, picocolors, warn } from '@vuepress/utils'
 import type { App, Plugin } from '../types/index.js'
 import { resolvePluginObject } from './resolvePluginObject.js'
 
@@ -13,7 +13,7 @@ export const appUse = (app: App, rawPlugin: Plugin): App => {
     return app
   }
 
-  log(`use plugin ${chalk.magenta(pluginObject.name)}`)
+  log(`use plugin ${picocolors.magenta(pluginObject.name)}`)
 
   // handle duplicated plugins
   if (pluginObject.multiple !== true) {
@@ -24,7 +24,7 @@ export const appUse = (app: App, rawPlugin: Plugin): App => {
       // remove the previous duplicated plugin
       app.pluginApi.plugins.splice(duplicateIndex, 1)
       warn(
-        `plugin ${chalk.magenta(
+        `plugin ${picocolors.magenta(
           pluginObject.name
         )} has been used multiple times, only the last one will take effect`
       )

--- a/packages/core/src/pluginApi/createHookQueue.ts
+++ b/packages/core/src/pluginApi/createHookQueue.ts
@@ -1,4 +1,4 @@
-import { chalk, debug, logger } from '@vuepress/utils'
+import { debug, logger, picocolors } from '@vuepress/utils'
 import type {
   HookItem,
   HookQueue,
@@ -27,7 +27,7 @@ export const createHookQueue = <T extends HooksName>(name: T): HookQueue<T> => {
       // process all hook items
       for (const item of items) {
         log(
-          `process ${chalk.magenta(name)} from ${chalk.magenta(
+          `process ${picocolors.magenta(name)} from ${picocolors.magenta(
             item.pluginName
           )}`
         )
@@ -43,9 +43,9 @@ export const createHookQueue = <T extends HooksName>(name: T): HookQueue<T> => {
           }
         } catch (e) {
           logger.error(
-            `error in hook ${chalk.magenta(name)} from ${chalk.magenta(
-              item.pluginName
-            )}`
+            `error in hook ${picocolors.magenta(
+              name
+            )} from ${picocolors.magenta(item.pluginName)}`
           )
           throw e
         }

--- a/packages/core/src/pluginApi/createHookQueue.ts
+++ b/packages/core/src/pluginApi/createHookQueue.ts
@@ -1,4 +1,4 @@
-import { debug, logger, picocolors } from '@vuepress/utils'
+import { colors, debug, logger } from '@vuepress/utils'
 import type {
   HookItem,
   HookQueue,
@@ -27,7 +27,7 @@ export const createHookQueue = <T extends HooksName>(name: T): HookQueue<T> => {
       // process all hook items
       for (const item of items) {
         log(
-          `process ${picocolors.magenta(name)} from ${picocolors.magenta(
+          `process ${colors.magenta(name)} from ${colors.magenta(
             item.pluginName
           )}`
         )
@@ -43,9 +43,9 @@ export const createHookQueue = <T extends HooksName>(name: T): HookQueue<T> => {
           }
         } catch (e) {
           logger.error(
-            `error in hook ${picocolors.magenta(
-              name
-            )} from ${picocolors.magenta(item.pluginName)}`
+            `error in hook ${colors.magenta(name)} from ${colors.magenta(
+              item.pluginName
+            )}`
           )
           throw e
         }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,12 +35,12 @@
     "@types/fs-extra": "^9.0.13",
     "@types/hash-sum": "^1.0.0",
     "@vuepress/shared": "workspace:*",
-    "chalk": "^5.1.2",
     "debug": "^4.3.4",
     "fs-extra": "^10.1.0",
     "globby": "^13.1.2",
     "hash-sum": "^2.0.0",
     "ora": "^6.1.2",
+    "picocolors": "^1.0.0",
     "upath": "^2.0.1"
   },
   "publishConfig": {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -3,10 +3,10 @@ import fs from 'fs-extra'
 import { globby } from 'globby'
 import hash from 'hash-sum'
 import ora from 'ora'
-import picocolors from 'picocolors'
+import colors from 'picocolors'
 import path from 'upath'
 
-export { debug, fs, globby, hash, ora, path, picocolors }
+export { debug, colors, fs, globby, hash, ora, path }
 
 export * from './getDirname.js'
 export * from './importFile.js'

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,12 +1,12 @@
-import chalk from 'chalk'
 import debug from 'debug'
 import fs from 'fs-extra'
 import { globby } from 'globby'
 import hash from 'hash-sum'
 import ora from 'ora'
+import picocolors from 'picocolors'
 import path from 'upath'
 
-export { debug, chalk, fs, globby, hash, ora, path }
+export { debug, picocolors, fs, globby, hash, ora, path }
 
 export * from './getDirname.js'
 export * from './importFile.js'

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -6,7 +6,7 @@ import ora from 'ora'
 import picocolors from 'picocolors'
 import path from 'upath'
 
-export { debug, picocolors, fs, globby, hash, ora, path }
+export { debug, fs, globby, hash, ora, path, picocolors }
 
 export * from './getDirname.js'
 export * from './importFile.js'

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,23 +1,23 @@
-import chalk from 'chalk'
+import picocolors from 'picocolors'
 
 export const info = (...args: any[]): void => {
-  console.log(chalk.cyan('info'), ...args)
+  console.log(picocolors.cyan('info'), ...args)
 }
 
 export const tip = (...args: any[]): void => {
-  console.log(chalk.blue('tip'), ...args)
+  console.log(picocolors.blue('tip'), ...args)
 }
 
 export const success = (...args: any[]): void => {
-  console.log(chalk.green('success'), ...args)
+  console.log(picocolors.green('success'), ...args)
 }
 
 export const warn = (...args: any[]): void => {
-  console.warn(chalk.yellow('warning'), ...args)
+  console.warn(picocolors.yellow('warning'), ...args)
 }
 
 export const error = (...args: any[]): void => {
-  console.error(chalk.red('error'), ...args)
+  console.error(picocolors.red('error'), ...args)
 }
 
 export const createError = (message?: string | undefined): Error => {

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,23 +1,23 @@
-import picocolors from 'picocolors'
+import colors from 'picocolors'
 
 export const info = (...args: any[]): void => {
-  console.log(picocolors.cyan('info'), ...args)
+  console.log(colors.cyan('info'), ...args)
 }
 
 export const tip = (...args: any[]): void => {
-  console.log(picocolors.blue('tip'), ...args)
+  console.log(colors.blue('tip'), ...args)
 }
 
 export const success = (...args: any[]): void => {
-  console.log(picocolors.green('success'), ...args)
+  console.log(colors.green('success'), ...args)
 }
 
 export const warn = (...args: any[]): void => {
-  console.warn(picocolors.yellow('warning'), ...args)
+  console.warn(colors.yellow('warning'), ...args)
 }
 
 export const error = (...args: any[]): void => {
-  console.error(picocolors.red('error'), ...args)
+  console.error(colors.red('error'), ...args)
 }
 
 export const createError = (message?: string | undefined): Error => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,24 +595,24 @@ importers:
       '@types/fs-extra': ^9.0.13
       '@types/hash-sum': ^1.0.0
       '@vuepress/shared': workspace:*
-      chalk: ^5.1.2
       debug: ^4.3.4
       fs-extra: ^10.1.0
       globby: ^13.1.2
       hash-sum: ^2.0.0
       ora: ^6.1.2
+      picocolors: ^1.0.0
       upath: ^2.0.1
     dependencies:
       '@types/debug': 4.1.7
       '@types/fs-extra': 9.0.13
       '@types/hash-sum': 1.0.0
       '@vuepress/shared': link:../shared
-      chalk: 5.1.2
       debug: 4.3.4
       fs-extra: 10.1.0
       globby: 13.1.2
       hash-sum: 2.0.0
       ora: 6.1.2
+      picocolors: 1.0.0
       upath: 2.0.1
 
 packages:


### PR DESCRIPTION
`picocolors` 14 times smaller and 2 times faster than `chalk`.

VitePress also use `picocolors`:
https://github.com/vuejs/vitepress/pull/659