### PR TITLE
docs: fix the routing related errors of the page document in the guide

### DIFF
--- a/docs/guide/page.md
+++ b/docs/guide/page.md
@@ -12,7 +12,7 @@ Assuming this is the directory structure of your markdown files:
 └─ docs
    ├─ guide
    │  ├─ getting-started.md
-   │  └─ README.md
+   │  └─ page.md
    ├─ contributing.md
    └─ README.md
 ```

--- a/docs/zh/guide/page.md
+++ b/docs/zh/guide/page.md
@@ -12,7 +12,7 @@ VuePress 是以 Markdown 为中心的。你项目中的每一个 Markdown 文件
 └─ docs
    ├─ guide
    │  ├─ getting-started.md
-   │  └─ README.md
+   │  └─ page.md
    ├─ contributing.md
    └─ README.md
 ```


### PR DESCRIPTION
假设这是你的 Markdown 文件所处的目录结构：

```sh
└─ docs
   ├─ guide
   │  ├─ getting-started.md
   │  └─ README.md  //修改了此处的中英文档，根据下方表格，显然这里应该是page.md
   ├─ contributing.md
   └─ README.md
```

将 `docs` 目录作为你的 [sourceDir](../reference/cli.md) ，例如你在运行 `vuepress dev docs` 命令。此时，你的 Markdown 文件对应的路由路径为：

|      相对路径      |       路由路径        |
|--------------------|----------------------|
| `/README.md`       | `/`                  |
| `/index.md`        | `/`                  |
| `/contributing.md` | `/contributing.html` |
| `/guide/README.md` | `/guide/`            |
| `/guide/page.md`   | `/guide/page.html`   |