### PR TITLE
docs: fix the routing related errors of the page document in the guide

### DIFF
--- a/docs/guide/page.md
+++ b/docs/guide/page.md
@@ -12,7 +12,7 @@ Assuming this is the directory structure of your markdown files:
 └─ docs
    ├─ guide
    │  ├─ getting-started.md
-   │  └─ README.md
+   │  └─ page.md
    ├─ contributing.md
    └─ README.md
 ```

--- a/docs/guide/page.md
+++ b/docs/guide/page.md
@@ -11,7 +11,7 @@ Assuming this is the directory structure of your markdown files:
 ```
 └─ docs
    ├─ guide
-   │  ├─ page.md
+   │  ├─ getting-started.md
    │  └─ README.md
    ├─ contributing.md
    └─ README.md
@@ -19,13 +19,13 @@ Assuming this is the directory structure of your markdown files:
 
 Take the `docs` directory as your [sourceDir](../reference/cli.md), e.g. you are running `vuepress dev docs` command. Then the route paths of your markdown files would be:
 
-|   Relative Path    |      Route Path      |
-|--------------------|----------------------|
-| `/README.md`       | `/`                  |
-| `/index.md`        | `/`                  |
-| `/contributing.md` | `/contributing.html` |
-| `/guide/README.md` | `/guide/`            |
-| `/guide/page.md`   | `/guide/page.html`   |
+| Relative Path               | Route Path                    |
+|-----------------------------|-------------------------------|
+| `/README.md`                | `/`                           |
+| `/index.md`                 | `/`                           |
+| `/contributing.md`          | `/contributing.html`          |
+| `/guide/README.md`          | `/guide/`                     |
+| `/guide/getting-started.md` | `/guide/getting-started.html` |
 
 ::: tip
 By default, both `README.md` and `index.md` would be converted to `index.html` and generate a slash-ending route path. However, it might cause conflicts if you want to keep both of the two files.

--- a/docs/guide/page.md
+++ b/docs/guide/page.md
@@ -11,8 +11,8 @@ Assuming this is the directory structure of your markdown files:
 ```
 └─ docs
    ├─ guide
-   │  ├─ getting-started.md
-   │  └─ page.md
+   │  ├─ page.md
+   │  └─ README.md
    ├─ contributing.md
    └─ README.md
 ```

--- a/docs/zh/guide/page.md
+++ b/docs/zh/guide/page.md
@@ -11,8 +11,8 @@ VuePress 是以 Markdown 为中心的。你项目中的每一个 Markdown 文件
 ```
 └─ docs
    ├─ guide
-   │  ├─ getting-started.md
-   │  └─ page.md
+   │  ├─ page.md
+   │  └─ README.md
    ├─ contributing.md
    └─ README.md
 ```

--- a/docs/zh/guide/page.md
+++ b/docs/zh/guide/page.md
@@ -12,7 +12,7 @@ VuePress 是以 Markdown 为中心的。你项目中的每一个 Markdown 文件
 └─ docs
    ├─ guide
    │  ├─ getting-started.md
-   │  └─ README.md
+   │  └─ page.md
    ├─ contributing.md
    └─ README.md
 ```

--- a/docs/zh/guide/page.md
+++ b/docs/zh/guide/page.md
@@ -11,7 +11,7 @@ VuePress 是以 Markdown 为中心的。你项目中的每一个 Markdown 文件
 ```
 └─ docs
    ├─ guide
-   │  ├─ page.md
+   │  ├─ getting-started.md
    │  └─ README.md
    ├─ contributing.md
    └─ README.md
@@ -19,13 +19,13 @@ VuePress 是以 Markdown 为中心的。你项目中的每一个 Markdown 文件
 
 将 `docs` 目录作为你的 [sourceDir](../reference/cli.md) ，例如你在运行 `vuepress dev docs` 命令。此时，你的 Markdown 文件对应的路由路径为：
 
-|      相对路径      |       路由路径        |
-|--------------------|----------------------|
-| `/README.md`       | `/`                  |
-| `/index.md`        | `/`                  |
-| `/contributing.md` | `/contributing.html` |
-| `/guide/README.md` | `/guide/`            |
-| `/guide/page.md`   | `/guide/page.html`   |
+| 相对路径                     | 路由路径                       |
+|-----------------------------|-------------------------------|
+| `/README.md`                | `/`                           |
+| `/index.md`                 | `/`                           |
+| `/contributing.md`          | `/contributing.html`          |
+| `/guide/README.md`          | `/guide/`                     |
+| `/guide/getting-started.md` | `/guide/getting-started.html` |
 
 ::: tip
 默认配置下， `README.md` 和 `index.md` 都会被转换成 `index.html` ，并且其对应的路由路径都是由斜杠结尾的。然而，如果你想同时保留这两个文件，就可能会造成冲突。


### PR DESCRIPTION
> 文档docs/guide/page.md部分原文如下

假设这是你的 Markdown 文件所处的目录结构：

```sh
└─ docs
   ├─ guide
   │  ├─ getting-started //根据下方路由路径表格，很显然，这里应该是page.md文件
   │  └─ README.md
   ├─ contributing.md
   └─ README.md
```

将 `docs` 目录作为你的 [sourceDir](../reference/cli.md) ，例如你在运行 `vuepress dev docs` 命令。此时，你的 Markdown 文件对应的路由路径为：

|      相对路径      |       路由路径        |
|--------------------|----------------------|
| `/README.md`       | `/`                  |
| `/index.md`        | `/`                  |
| `/contributing.md` | `/contributing.html` |
| `/guide/README.md` | `/guide/`            |
| `/guide/page.md`   | `/guide/page.html`   |