### PR TITLE
Revert "perf: render pages in parallel"

### DIFF
--- a/packages/bundler-vite/src/build/build.ts
+++ b/packages/bundler-vite/src/build/build.ts
@@ -1,6 +1,6 @@
 import type { CreateVueAppFunction } from '@vuepress/client'
 import type { App, Bundler } from '@vuepress/core'
-import { debug, fs, importFile, withSpinner } from '@vuepress/utils'
+import { colors, debug, fs, importFile, withSpinner } from '@vuepress/utils'
 import type { OutputAsset, OutputChunk, RollupOutput } from 'rollup'
 import { build as viteBuild } from 'vite'
 import { resolveViteConfig } from '../resolveViteConfig.js'
@@ -73,21 +73,20 @@ export const build = async (
     const { renderToString } = await import('vue/server-renderer')
 
     // pre-render pages to html files
-    await Promise.all(
-      app.pages.map((page) =>
-        renderPage({
-          app,
-          page,
-          vueApp,
-          vueRouter,
-          renderToString,
-          ssrTemplate,
-          output: clientOutput.output,
-          outputEntryChunk: clientEntryChunk,
-          outputCssAsset: clientCssAsset,
-        })
-      )
-    )
+    for (const page of app.pages) {
+      if (spinner) spinner.text = `Rendering pages ${colors.magenta(page.path)}`
+      await renderPage({
+        app,
+        page,
+        vueApp,
+        vueRouter,
+        renderToString,
+        ssrTemplate,
+        output: clientOutput.output,
+        outputEntryChunk: clientEntryChunk,
+        outputCssAsset: clientCssAsset,
+      })
+    }
   })
 
   // keep the server bundle files in debug mode

--- a/packages/bundler-webpack/src/build/build.ts
+++ b/packages/bundler-webpack/src/build/build.ts
@@ -1,6 +1,12 @@
 import type { CreateVueAppFunction } from '@vuepress/client'
 import type { App, Bundler } from '@vuepress/core'
-import { debug, fs, importFileDefault, withSpinner } from '@vuepress/utils'
+import {
+  colors,
+  debug,
+  fs,
+  importFileDefault,
+  withSpinner,
+} from '@vuepress/utils'
 import webpack from 'webpack'
 import { resolveWebpackConfig } from '../resolveWebpackConfig.js'
 import type { WebpackBundlerOptions } from '../types.js'
@@ -90,22 +96,23 @@ export const build = async (
     const { renderToString } = await import('vue/server-renderer')
 
     // pre-render pages to html files
-    await Promise.all(
-      app.pages.map((page) =>
-        renderPage({
-          app,
-          page,
-          vueApp,
-          vueRouter,
-          renderToString,
-          ssrTemplate,
-          allFilesMeta,
-          initialFilesMeta,
-          asyncFilesMeta,
-          moduleFilesMetaMap,
-        })
-      )
-    )
+    for (const page of app.pages) {
+      if (spinner) {
+        spinner.text = `Rendering pages ${colors.magenta(page.path)}`
+      }
+      await renderPage({
+        app,
+        page,
+        vueApp,
+        vueRouter,
+        renderToString,
+        ssrTemplate,
+        allFilesMeta,
+        initialFilesMeta,
+        asyncFilesMeta,
+        moduleFilesMetaMap,
+      })
+    }
   })
 
   // keep the server bundle files in debug mode


### PR DESCRIPTION
Reverts vuepress/vuepress-next#1094

SSG result is not expected.

Lines like this absolutely will fail if this is done parrally.

https://github.com/vuepress/vuepress-next/blob/45c8e1cc3029bb68ab59ed5155b54bd774769231/packages/bundler-vite/src/build/renderPage.ts#L36-L37

https://vuepress.github.io SSG result is 404 page now.

cc @meteorlxy  @sanjaiyan-dev 