### PR TITLE
docs: use vuepress package in migration guide

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -47,7 +47,7 @@ Using a theme via string is not supported. Import the theme directly.
 -   },
 - }
 
-+ import { defaultTheme } from '@vuepress/theme-default'
++ import { defaultTheme } from 'vuepress'
 + export default {
 +   theme: defaultTheme({
 +     // default theme config


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/vuepress/vuepress-next/blob/main/docs/contributing.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Other

### Description

import default theme from package '@vuepress/theme-default' can cause an error: 

**Before**

<img width="1103" alt="图片" src="https://user-images.githubusercontent.com/92929085/214484057-3b1435cd-4910-4bfb-8c96-1d46b1a7f47f.png">

Instead, I recommand import directly from 'vuepress', as is shown from the theme config.

```js
import { defaultTheme } from 'vuepress';
```
**After**

![图片](https://user-images.githubusercontent.com/92929085/214484795-888c2c23-df7b-4433-9f27-a1eb2a93ab77.png)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Screenshots

<!-- If your PR includes UI changes, please provide before/after screenshots. If there are any other images that add context to the PR, add them here as well -->
