### PR TITLE
fix(theme-default): fix inactive style

### DIFF
--- a/ecosystem/theme-default/src/client/styles/navbar.scss
+++ b/ecosystem/theme-default/src/client/styles/navbar.scss
@@ -43,15 +43,16 @@
   .navbar {
     padding-left: 4rem;
 
-    .can-hide {
-      display: none;
-    }
-
     .site-name {
-      width: calc(100vw - 9.4rem);
+      display: block;
+      width: calc(100vw - 11rem);
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
+    }
+
+    .can-hide {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/vuepress/vuepress-next/blob/main/docs/contributing.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Text overflow ellipsis is inactive because `span.site-name` is an inline element.

The style `width` takes no effect.

The rule `.can-hide` is moved to ensure it can overrides `display: block;` when there is a navbarBrandLogo.

The `width` is changed to adapt the situation that there is both a ColorModeSwitch and a NavbarSearch.

### Screenshots

<!-- If your PR includes UI changes, please provide before/after screenshots. If there are any other images that add context to the PR, add them here as well -->

**Before**

<img width="1545" alt="Screenshot 2023-02-15 at 17 24 21" src="https://user-images.githubusercontent.com/22659150/218987461-21a4c5a7-b0b1-4e1f-a3b0-2ceba6a245b7.png">

**After**

<img width="1403" alt="Screenshot 2023-02-15 at 17 37 49" src="https://user-images.githubusercontent.com/22659150/218990345-026200b0-a3f9-4887-8fc3-26af899e5fbf.png">
