### PR TITLE
fix(plugin-docsearch): open docsearch with slash key before run initi…

### DIFF
--- a/ecosystem/plugin-docsearch/src/client/composables/useDocsearchHotkeyListener.ts
+++ b/ecosystem/plugin-docsearch/src/client/composables/useDocsearchHotkeyListener.ts
@@ -5,10 +5,15 @@ import { useEventListener } from '@vueuse/core'
  */
 export const useDocsearchHotkeyListener = (callback: () => void): void => {
   const remove = useEventListener('keydown', (event) => {
-    if (event.key === 'k' && (event.ctrlKey || event.metaKey)) {
-      event.preventDefault()
-      callback()
-      remove()
+    const isHotKeyBind = event.key === 'k' && (event.ctrlKey || event.metaKey)
+    const isSlashKey = event.key === '/'
+
+    if (!isSlashKey && !isHotKeyBind) {
+      return
     }
+
+    event.preventDefault()
+    callback()
+    remove()
   })
 }


### PR DESCRIPTION
…alize

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [X] Read the [Contributing Guidelines](https://github.com/vuepress/vuepress-next/blob/main/docs/contributing.md).
- [X] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

Solving this problem: https://github.com/vuejs/docs/issues/2240. 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

### Description
Previously, the `initializate` method was called in onMounted `Docsearch.ts`, but there was a change that removed it and the method responsible for triggering `docsearch` before executing the initializate became `useDocsearchHotkeyListener`, this method defines a `keydown` eventLintener when mounting the component.

My change was to add the '/' key to the `useDocsearchHotkeyListener` validation.

