### PR TITLE
Fixing Document Errors

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -70,7 +70,7 @@ pnpm add -D vuepress@next @vuepress/client@next vue
   <CodeGroupItem title="YARN">
 
 ```bash
-yarn add -D vuepress@next
+yarn add -D vuepress@next @vuepress/client@next vue
 ```
 
   </CodeGroupItem>
@@ -78,7 +78,7 @@ yarn add -D vuepress@next
   <CodeGroupItem title="NPM">
 
 ```bash
-npm install -D vuepress@next
+npm install -D vuepress@next @vuepress/client@next vue
 ```
 
   </CodeGroupItem>

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -71,7 +71,7 @@ pnpm add -D vuepress@next @vuepress/client@next vue
   <CodeGroupItem title="YARN">
 
 ```bash
-yarn add -D vuepress@next
+yarn add -D vuepress@next @vuepress/client@next vue
 ```
 
   </CodeGroupItem>
@@ -79,7 +79,7 @@ yarn add -D vuepress@next
   <CodeGroupItem title="NPM">
 
 ```bash
-npm install -D vuepress@next
+npm install -D vuepress@next @vuepress/client@next vue
 ```
 
   </CodeGroupItem>


### PR DESCRIPTION
【Fixing Document Errors】
There are omissions and inconsistencies in the document.
According to the current npm document, the project cannot be started at all.

【修复文档错误】
文档内容存在遗漏和不一致
按照当前的 npm 文档操作，工程根本启动不起来