### PR TITLE
chore: update tsconfig

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     "noEmitOnError": true,
     "noImplicitAny": false,
     "skipLibCheck": true,
-    "target": "ES2020"
+    "verbatimModuleSyntax": true,
+    "target": "ES2021"
   }
 }


### PR DESCRIPTION
- Node16 targets ES2021
- https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax supported by typescript to force marking types, so we no longer need the eslint rule which is slower.