### PR TITLE
feat(plugin-git): remove duplicate no-reply contributors

### DIFF
--- a/ecosystem/plugin-git/src/node/utils/getContributors.ts
+++ b/ecosystem/plugin-git/src/node/utils/getContributors.ts
@@ -27,7 +27,7 @@ export const getContributors = async (
       // If one of the contributors is a "noreply" email address, *and* there's
       // already a contributor *with the same name*, it is very likely a duplicate,
       // so it can be removed.
-      if (item.email.split('@')[1]?.match(/no-?reply/')) {
+      if (item.email.split('@')[1]?.match(/no-?reply/)) {
         return index === self.findIndex((t) => t.name === item.name)
       }
       return true

--- a/ecosystem/plugin-git/src/node/utils/getContributors.ts
+++ b/ecosystem/plugin-git/src/node/utils/getContributors.ts
@@ -24,13 +24,13 @@ export const getContributors = async (
       commits: Number.parseInt(commits, 10),
     }))
     .filter((item, index, self) => {
-      // If one of the contributors is a "noreply" email address, *and* there's
-      // already a contributor *with the same name*, it is very likely a duplicate,
+      // If one of the contributors is a "noreply" email address, and there's
+      // already a contributor with the same name, it is very likely a duplicate,
       // so it can be removed.
       if (item.email.split('@')[1]?.match(/no-?reply/)) {
         const realIndex = self.findIndex((t) => t.name === item.name)
         if (realIndex !== index) {
-          // Before filtering, update the "real" contributor to also include the noreply's commits
+          // Update the "real" contributor to also include the noreply's commits
           self[realIndex].commits += item.commits
           return false
         }

--- a/ecosystem/plugin-git/src/node/utils/getContributors.ts
+++ b/ecosystem/plugin-git/src/node/utils/getContributors.ts
@@ -28,7 +28,13 @@ export const getContributors = async (
       // already a contributor *with the same name*, it is very likely a duplicate,
       // so it can be removed.
       if (item.email.split('@')[1]?.match(/no-?reply/)) {
-        return index === self.findIndex((t) => t.name === item.name)
+        const realIndex = self.findIndex((t) => t.name === item.name)
+        if (realIndex !== index) {
+          // Before filtering, update the "real" contributor to also include the noreply's commits
+          self[realIndex].commits += item.commits
+          return false
+        }
+        return true
       }
       return true
     })

--- a/ecosystem/plugin-git/src/node/utils/getContributors.ts
+++ b/ecosystem/plugin-git/src/node/utils/getContributors.ts
@@ -27,11 +27,7 @@ export const getContributors = async (
       // If one of the contributors is a "noreply" email address, *and* there's
       // already a contributor *with the same name*, it is very likely a duplicate,
       // so it can be removed.
-      if (
-        item.email.includes('@') &&
-        (item.email.split('@')[1].includes('noreply') ||
-          item.email.split('@')[1].includes('no-reply'))
-      ) {
+      if (item.email.split('@')[1]?.match(/no-?reply/')) {
         return index === self.findIndex((t) => t.name === item.name)
       }
       return true

--- a/ecosystem/plugin-git/src/node/utils/getContributors.ts
+++ b/ecosystem/plugin-git/src/node/utils/getContributors.ts
@@ -23,4 +23,17 @@ export const getContributors = async (
       email,
       commits: Number.parseInt(commits, 10),
     }))
+    .filter((item, index, self) => {
+      // If one of the contributors is a "noreply" email address, *and* there's
+      // already a contributor *with the same name*, it is very likely a duplicate,
+      // so it can be removed.
+      if (
+        item.email.includes('@') &&
+        (item.email.split('@')[1].includes('noreply') ||
+          item.email.split('@')[1].includes('no-reply'))
+      ) {
+        return index === self.findIndex((t) => t.name === item.name)
+      }
+      return true
+    })
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [X] Read the [Contributing Guidelines](https://github.com/vuepress/vuepress-next/blob/main/docs/contributing.md).
- [X] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Other

### Description

A user might use multiple mechanisms of contributing code, some directly using their username and email, and others automated, typically with a "noreply" email address. Right now, this causes pages that use the "contributor" to have this somewhat awkward field:

<img width="326" alt="rendered" src="https://github.com/vuejs/vuepress/assets/2678195/a8570adf-59e4-4ba5-80de-589ee0795e76">

This change treats the noreply addresses as the "same contributor", if one exists with the same name.

If a file has no such "noreply" addresses, or if there is no corresponding "normal" contributor, the field is unchanged.

Discussion: https://github.com/vuepress/vuepress-next/discussions/1336

### Changes

**Before**
```
plugin-git % pnpm build && node -e 'import("./lib/node/utils/getContributors.js").then((mod)=>{mod.getContributors(["runatlantis.io/docs/README.md"], "/Users/lukemassa/atlantis").then((value)=>{console.log(value)})})'

> @vuepress/plugin-git@2.0.0-beta.63 build /Users/lukemassa/vuepress-next/ecosystem/plugin-git
> tsc -b tsconfig.build.json

[
  { name: 'Luke Kysow', email: 'lkysow@gmail.com', commits: 6 },
  {
    name: 'Luke Kysow',
    email: '1034429+lkysow@users.noreply.github.com',
    commits: 2
  }
]
```

**After**
```
plugin-git % pnpm build && node -e 'import("./lib/node/utils/getContributors.js").then((mod)=>{mod.getContributors(["runatlantis.io/docs/README.md"], "/Users/lukemassa/atlantis").then((value)=>{console.log(value)})})'

> @vuepress/plugin-git@2.0.0-beta.63 build /Users/lukemassa/vuepress-next/ecosystem/plugin-git
> tsc -b tsconfig.build.json

[ { name: 'Luke Kysow', email: 'lkysow@gmail.com', commits: 6 } ]
```