### PR TITLE
fix(client): fallback page lang to site lang (close #1365)

### DIFF
--- a/packages/client/src/resolvers.ts
+++ b/packages/client/src/resolvers.ts
@@ -92,10 +92,8 @@ export const resolvers = reactive({
    *
    * It would be used as the `lang` attribute of `<html>` tag
    */
-  resolvePageLang: (
-    page: PageData,
-    siteLocale: SiteLocaleData
-  ): PageLang => page.lang || siteLocale.lang || 'en-US',
+  resolvePageLang: (page: PageData, siteLocale: SiteLocaleData): PageLang =>
+    page.lang || siteLocale.lang || 'en-US',
 
   /**
    * Resolve layout component of current page

--- a/packages/client/src/resolvers.ts
+++ b/packages/client/src/resolvers.ts
@@ -92,7 +92,10 @@ export const resolvers = reactive({
    *
    * It would be used as the `lang` attribute of `<html>` tag
    */
-  resolvePageLang: (page: PageData): PageLang => page.lang || 'en',
+  resolvePageLang: (
+    page: PageData,
+    siteLocale: SiteLocaleData
+  ): PageLang => page.lang || siteLocale.lang || 'en-US',
 
   /**
    * Resolve layout component of current page

--- a/packages/client/src/setupGlobalComputed.ts
+++ b/packages/client/src/setupGlobalComputed.ts
@@ -82,7 +82,7 @@ export const setupGlobalComputed = (
       siteLocaleData.value
     )
   )
-  const pageLang = computed(() => 
+  const pageLang = computed(() =>
     resolvers.resolvePageLang(pageData.value, siteLocaleData.value)
   )
   const pageLayout = computed(() =>

--- a/packages/client/src/setupGlobalComputed.ts
+++ b/packages/client/src/setupGlobalComputed.ts
@@ -82,7 +82,9 @@ export const setupGlobalComputed = (
       siteLocaleData.value
     )
   )
-  const pageLang = computed(() => resolvers.resolvePageLang(pageData.value))
+  const pageLang = computed(() => 
+    resolvers.resolvePageLang(pageData.value, siteLocaleData.value)
+  )
   const pageLayout = computed(() =>
     resolvers.resolvePageLayout(pageData.value, layouts.value)
   )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/vuepress/vuepress-next/blob/main/docs/contributing.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

### Description

Some pages were rendered with the wrong locale lang set. I have updated the resolver to look at the page data and the siteLocaleData. Additionally, I have set the default to be the same as the other Locale classes: `en-US`. This should ensure all pages have the correct locale lang set

fixes https://github.com/vuepress/vuepress-next/issues/1365
